### PR TITLE
Bubble up versions from jobinfo to rover

### DIFF
--- a/martian/Cargo.toml
+++ b/martian/Cargo.toml
@@ -16,6 +16,7 @@ failure = "*"
 failure_derive = "*"
 heck = "*"
 tempfile = "3"
+rustc_version = "0.2"
 
 [dev-dependencies]
 indoc = "0.3.3"

--- a/martian/src/stage.rs
+++ b/martian/src/stage.rs
@@ -1,3 +1,4 @@
+use crate::metadata::Version;
 use crate::mro::{MartianStruct, MroMaker};
 use crate::utils::{obj_decode, obj_encode};
 use crate::Metadata;
@@ -303,15 +304,17 @@ pub struct MartianRover {
     mem_gb: usize,
     threads: usize,
     vmem_gb: usize,
+    version: Version,
 }
 
 impl<'a> From<&'a Metadata<'a>> for MartianRover {
     fn from(md: &Metadata) -> MartianRover {
         MartianRover {
             files_path: PathBuf::from(&md.files_path),
-            mem_gb: md.get_memory_allocation(),
-            threads: md.get_threads_allocation(),
-            vmem_gb: md.get_virtual_memory_allocation(),
+            mem_gb: md.jobinfo.mem_gb,
+            threads: md.jobinfo.threads,
+            vmem_gb: md.jobinfo.vmem_gb,
+            version: md.jobinfo.version.clone(),
         }
     }
 }
@@ -333,6 +336,7 @@ impl MartianRover {
             mem_gb: resource.mem_gb.unwrap() as usize,
             threads: resource.threads.unwrap() as usize,
             vmem_gb: resource.vmem_gb.unwrap() as usize,
+            version: Version::default(),
         }
     }
     ///
@@ -372,6 +376,12 @@ impl MartianRover {
     }
     pub fn files_path(&self) -> &Path {
         self.files_path.as_path()
+    }
+    pub fn martian_version(&self) -> String {
+        self.version.martian.clone()
+    }
+    pub fn pipelines_version(&self) -> String {
+        self.version.pipelines.clone()
     }
 }
 

--- a/martian/tests/jobinfo.json
+++ b/martian/tests/jobinfo.json
@@ -1,0 +1,108 @@
+{
+    "name": "ID.tmp.SUM_SQUARES.SUM_SQUARES.fork0.chnk0",
+    "pid": 676150,
+    "host": "myhost.com",
+    "type": "local",
+    "cwd": "/path/to/files",
+    "rusage": {
+        "self": {
+            "ru_maxrss": 14516,
+            "ru_ixrss": 0,
+            "ru_idrss": 0,
+            "ru_minflt": 618,
+            "ru_majflt": 0,
+            "ru_nswap": 0,
+            "ru_utime": 0.004,
+            "ru_stime": 0,
+            "ru_inblock": 0,
+            "ru_oublock": 48,
+            "ru_msgsnd": 0,
+            "ru_msgrcv": 0,
+            "ru_nsignals": 0,
+            "ru_nivcsw": 2
+        },
+        "children": {
+            "ru_maxrss": 8740,
+            "ru_ixrss": 0,
+            "ru_idrss": 0,
+            "ru_minflt": 546,
+            "ru_majflt": 6,
+            "ru_nswap": 0,
+            "ru_utime": 0.048,
+            "ru_stime": 0,
+            "ru_inblock": 15144,
+            "ru_oublock": 40,
+            "ru_msgsnd": 0,
+            "ru_msgrcv": 0,
+            "ru_nsignals": 0,
+            "ru_nivcsw": 6
+        }
+    },
+    "used_bytes": {
+        "rss": 14864384,
+        "shared": 4882432,
+        "vmem": 307068928,
+        "text": 2240512,
+        "stack": 155435008,
+        "proc_count": 1
+    },
+    "io": {
+        "total": {
+            "read": {
+                "sysc": 5,
+                "bytes": 0
+            },
+            "write": {
+                "sysc": 0,
+                "bytes": 0
+            }
+        },
+        "max": {
+            "read": {
+                "sysc": 343.89359491989376,
+                "bytes": 0
+            },
+            "write": {
+                "sysc": 0,
+                "bytes": 0
+            }
+        },
+        "dev": {
+            "read": {
+                "sysc": 0,
+                "bytes": 0
+            },
+            "write": {
+                "sysc": 0,
+                "bytes": 0
+            }
+        }
+    },
+    "wallclock": {
+        "start": "2019-11-05 17:22:38",
+        "end": "2019-11-05 17:22:38",
+        "duration_seconds": 0.079323697
+    },
+    "threads": 1,
+    "memGB": 1,
+    "vmemGB": 4,
+    "profile_mode": "disable",
+    "stackvars_flag": "stackvars",
+    "monitor_flag": "monitor",
+    "invocation": {
+        "call": "SUM_SQUARES",
+        "args": {
+            "values": [
+                1,
+                2,
+                3
+            ]
+        },
+        "sweepargs": [],
+        "mro_file": "stage.mro"
+    },
+    "version": {
+        "martian": "v3.2.2",
+        "pipelines": "7000.1.52-187"
+    }
+}


### PR DESCRIPTION
You can now do
```
let _ = rover.pipelines_version();
let _ = rover.martian_version();
```