### PR TITLE
Support structs as mro args/outs

### DIFF
--- a/cargo-martian/src/template.rs
+++ b/cargo-martian/src/template.rs
@@ -238,7 +238,7 @@ fn main() -> Result<(), Error> {open}
         // If you want explicit control over the log level, use:
         // let runner = runner.log_level();
         // run the stage
-        let (retcode, _) = runner.run(args.arg_adapter);
+        let retcode = runner.run(args.arg_adapter);
         // return from the process
         std::sys::exit(retcode);
     {close} else if args.cmd_mro {open}

--- a/martian-derive/Cargo.toml
+++ b/martian-derive/Cargo.toml
@@ -19,3 +19,4 @@ proc-macro = true
 [dev-dependencies]
 trybuild = "1.0"
 indoc = "0.3"
+pretty_assertions = "0.6.1"

--- a/martian-derive/Cargo.toml
+++ b/martian-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-derive"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 

--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -520,6 +520,7 @@ pub fn martian_struct(item: proc_macro::TokenStream) -> proc_macro::TokenStream 
     // Handle generics in the struct
     let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
     let item_ident = item_struct.ident.clone();
+    let item_ident_str = item_ident.to_string();
     let final_token = quote![
         #[automatically_derived]
         impl #impl_generics ::martian::MartianStruct for #item_ident #ty_generics #where_clause {
@@ -527,6 +528,16 @@ pub fn martian_struct(item: proc_macro::TokenStream) -> proc_macro::TokenStream 
                 vec![
                     #(#vec_inner),*
                 ]
+            }
+        }
+
+        #[automatically_derived]
+        impl #impl_generics ::martian::AsMartianPrimaryType for #item_ident #ty_generics #where_clause {
+            fn as_martian_primary_type() -> ::martian::MartianPrimaryType {
+                let fields = <#item_ident #ty_generics as ::martian::MartianStruct>::mro_fields();
+                ::martian::MartianPrimaryType::Struct(
+                    ::martian::mro::StructDef::new(#item_ident_str.into(), fields)
+                )
             }
         }
     ];

--- a/martian-derive/tests/mro/test_empty_split.mro
+++ b/martian-derive/tests/mro/test_empty_split.mro
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
+#
+# WARNING: This file is auto-generated.
+# DO NOT MODIFY THIS FILE DIRECTLY
+#
+
 stage CHUNK_READS(
     in  map[] chunks,
     in  int   reads_per_file,

--- a/martian-derive/tests/mro/test_main_only.mro
+++ b/martian-derive/tests/mro/test_main_only.mro
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
+#
+# WARNING: This file is auto-generated.
+# DO NOT MODIFY THIS FILE DIRECTLY
+#
+
 stage SUM_SQUARES(
     in  float[] values,
     out float   sum_sq,

--- a/martian-derive/tests/mro/test_non_empty_split.mro
+++ b/martian-derive/tests/mro/test_non_empty_split.mro
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
+#
+# WARNING: This file is auto-generated.
+# DO NOT MODIFY THIS FILE DIRECTLY
+#
+
 stage CHUNK_READS(
     in  map[] chunks,
     in  int   reads_per_file,

--- a/martian-derive/tests/mro/test_retain.mro
+++ b/martian-derive/tests/mro/test_retain.mro
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
+#
+# WARNING: This file is auto-generated.
+# DO NOT MODIFY THIS FILE DIRECTLY
+#
+
 filetype bam;
 filetype bam.bai;
 

--- a/martian-derive/tests/mro/test_retain.mro
+++ b/martian-derive/tests/mro/test_retain.mro
@@ -1,4 +1,3 @@
-
 filetype bam;
 filetype bam.bai;
 

--- a/martian-derive/tests/mro/test_struct.mro
+++ b/martian-derive/tests/mro/test_struct.mro
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
+#
+# WARNING: This file is auto-generated.
+# DO NOT MODIFY THIS FILE DIRECTLY
+#
+
+filetype fastq;
+filetype json;
+
+struct ChemistryDef(
+    string name,
+    string barcode_read,
+    int    barcode_length,
+)
+
+struct Config(
+    SampleDef[] sample_def,
+    path        reference_path,
+    int         force_cells,
+    json        primers,
+)
+
+struct RnaChunk(
+    ChemistryDef chemistry_def,
+    int          chunk_id,
+    fastq        r1,
+)
+
+struct SampleDef(
+    path read_path,
+)
+
+stage SETUP_CHUNKS(
+    in  Config       config,
+    in  ChemistryDef custom_chemistry_def,
+    out RnaChunk[]   chunks,
+    out ChemistryDef chemistry_def,
+    src comp         "my_adapter martian setup_chunks",
+)

--- a/martian-derive/tests/mro/test_with_custom_type.mro
+++ b/martian-derive/tests/mro/test_with_custom_type.mro
@@ -1,4 +1,3 @@
-
 filetype json;
 
 stage DETECT_CHEMISTRY(

--- a/martian-derive/tests/mro/test_with_custom_type.mro
+++ b/martian-derive/tests/mro/test_with_custom_type.mro
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
+#
+# WARNING: This file is auto-generated.
+# DO NOT MODIFY THIS FILE DIRECTLY
+#
+
 filetype json;
 
 stage DETECT_CHEMISTRY(

--- a/martian-derive/tests/mro/test_with_filetype.mro
+++ b/martian-derive/tests/mro/test_with_filetype.mro
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
+#
+# WARNING: This file is auto-generated.
+# DO NOT MODIFY THIS FILE DIRECTLY
+#
+
 filetype json;
 filetype txt;
 

--- a/martian-derive/tests/mro/test_with_filetype.mro
+++ b/martian-derive/tests/mro/test_with_filetype.mro
@@ -1,4 +1,3 @@
-
 filetype json;
 filetype txt;
 

--- a/martian-filetypes/Cargo.toml
+++ b/martian-filetypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-filetypes"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Sreenath Krishnan <sreenathk.89@gmail.com>"]
 edition = "2018"
 

--- a/martian/Cargo.toml
+++ b/martian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 

--- a/martian/Cargo.toml
+++ b/martian/Cargo.toml
@@ -21,6 +21,7 @@ rayon = { version = ">=1.0", optional = true }
 
 [dev-dependencies]
 indoc = "0.3.3"
+pretty_assertions = "0.6.1"
 
 [features]
 default = []

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -5,19 +5,18 @@
 //! For a guide style documentation and examples, visit: [https://martian-lang.github.io/martian-rust/](https://martian-lang.github.io/martian-rust/#/)
 //!
 
-
 use std::collections::HashMap;
 use std::fmt::Write as FmtWrite;
 use std::fs::File;
+use std::io;
 use std::io::Write as IoWrite;
-use std::os::unix::io::{IntoRawFd, FromRawFd};
+use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::panic;
 use std::path::Path;
-use std::io;
 
 use backtrace::Backtrace;
-use log::{error, info};
 use chrono::Local;
+use log::{error, info};
 
 pub use failure::{format_err, Error, ResultExt};
 
@@ -37,7 +36,6 @@ pub use mro::*;
 
 pub use log::LevelFilter;
 pub mod prelude;
-
 
 pub fn initialize(args: Vec<String>) -> Result<Metadata, Error> {
     let mut md = Metadata::new(args);
@@ -61,7 +59,6 @@ fn write_errors(msg: &str, is_assert: bool) -> Result<(), Error> {
     let _ = err_file.into_raw_fd();
     Ok(())
 }
-
 
 fn setup_logging(log_file: File, level: LevelFilter) {
     let base_config = fern::Dispatch::new().level(level);
@@ -103,20 +100,17 @@ impl<S: std::hash::BuildHasher> MartianAdapter<S> {
     /// Set the minimum severity level of log messages that are emitted to the Martian
     /// _log file.
     pub fn log_level(self, log_level: LevelFilter) -> MartianAdapter<S> {
-        MartianAdapter {
-            log_level,
-            .. self
-        }
+        MartianAdapter { log_level, ..self }
     }
 
     ///  Set `is_error_assert`, predicate determining whether to emit an error as an ASSERT
     ///  to Martian. ASSERT errors indicate an unrecoverable configuration error, and will
-    ///  prevent the user from restarting the pipeline. The is_error_assert function should 
+    ///  prevent the user from restarting the pipeline. The is_error_assert function should
     ///  use downcasting to match the error against a set of error types that should generate an assert.
     pub fn assert_if<F: 'static + Fn(&Error) -> bool>(self, predicate: F) -> MartianAdapter<S> {
         MartianAdapter {
             is_error_assert: Box::new(predicate),
-            .. self
+            ..self
         }
     }
 
@@ -134,14 +128,9 @@ impl<S: std::hash::BuildHasher> MartianAdapter<S> {
     /// for unit testing purposes.
     #[must_use = "Martian stage binaries should call std::process::exit() on the return_code"]
     pub fn run_get_error(self, args: Vec<String>) -> (i32, Option<Error>) {
-        martian_entry_point(
-            args,
-            self.stage_map,
-            self.log_level,
-            self.is_error_assert)
+        martian_entry_point(args, self.stage_map, self.log_level, self.is_error_assert)
     }
 }
-
 
 /// See docs on MartianAdapter methods for details.
 fn martian_entry_point<S: std::hash::BuildHasher>(
@@ -159,7 +148,6 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
     let log_file: File = unsafe { File::from_raw_fd(3) };
     setup_logging(log_file, level);
 
-
     // setup Martian metadata (and an extra copy for use in the panic handler
     let _md = initialize(args).context("IO Error initializing stage");
 
@@ -168,7 +156,7 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
         Ok(m) => m,
         Err(e) => {
             let _ = write_errors(&format!("{:?}", e), false);
-            return (1, Some(e.into()))
+            return (1, Some(e.into()));
         }
     };
 
@@ -182,7 +170,7 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
         Ok(s) => s,
         Err(e) => {
             let _ = write_errors(&format!("{:?}", e), false);
-            return (1, Some(e))
+            return (1, Some(e));
         }
     };
 
@@ -217,13 +205,13 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
         // write to _log
         error!("{}", msg);
 
-        // write stack trace to to _stackvars. 
+        // write stack trace to to _stackvars.
         // this will just give up if any errors are encountere
         let bt_string = format!("{:?}", backtrace);
         let _ = File::create(&stackvars_path).map(|mut f| {
             let _ = f.write_all(bt_string.as_bytes());
         });
-    
+
         // write to _errors
         let _ = write_errors(&msg, false);
 
@@ -231,21 +219,17 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
         p(info);
     }));
 
-    let result = 
-        if md.stage_type == "split" {
-           stage.split(&mut md)
-        } else if md.stage_type == "main" {
-            stage.main(&mut md)
-        } else if md.stage_type == "join" {
-            stage.join(&mut md)
-        } else {
-            panic!("Unrecognized stage type");
-        };
-
-
+    let result = if md.stage_type == "split" {
+        stage.split(&mut md)
+    } else if md.stage_type == "main" {
+        stage.main(&mut md)
+    } else if md.stage_type == "join" {
+        stage.join(&mut md)
+    } else {
+        panic!("Unrecognized stage type");
+    };
 
     let res = match result {
-
         // exit code = 0
         Ok(()) => (0, None),
 
@@ -264,11 +248,12 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
 }
 
 const MRO_HEADER: &str = r#"#
-# Copyright (c) 2019 10X Genomics, Inc. All rights reserved.
+# Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
 #
 # WARNING: This file is auto-generated.
 # DO NOT MODIFY THIS FILE DIRECTLY
 #
+
 "#;
 pub fn martian_make_mro(
     file_name: Option<impl AsRef<Path>>,

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -276,15 +276,7 @@ pub fn martian_make_mro(
         }
     }
 
-    let mut filetype_header = FiletypeHeader::default();
-    let mut mro_string = String::new();
-    for stage_mro in mro_registry {
-        filetype_header.add_stage(&stage_mro);
-        writeln!(&mut mro_string, "{}", stage_mro)?;
-    }
-    mro_string.pop();
-
-    let final_mro_string = format!("{}{}{}", MRO_HEADER, filetype_header, mro_string);
+    let final_mro_string = make_mro_string(&mro_registry);
     match file_name {
         Some(f) => {
             let mut output = File::create(f)?;
@@ -295,4 +287,21 @@ pub fn martian_make_mro(
         }
     }
     Ok(())
+}
+
+pub fn make_mro_string(mro_registry: &[StageMro]) -> String {
+    let mut filetype_header = FiletypeHeader::default();
+    let mut struct_header = StructHeader::default();
+    let mut mro_string = String::new();
+    for stage_mro in mro_registry {
+        filetype_header.add_stage(&stage_mro);
+        struct_header.add_stage(&stage_mro);
+        writeln!(&mut mro_string, "{}", stage_mro).unwrap();
+    }
+    mro_string.pop();
+
+    format!(
+        "{}{}{}{}",
+        MRO_HEADER, filetype_header, struct_header, mro_string
+    )
 }

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -85,6 +85,12 @@ pub struct StructDef {
     fields: Vec<MroField>,
 }
 
+impl StructDef {
+    pub fn new(name: String, fields: Vec<MroField>) -> Self {
+        StructDef { name, fields }
+    }
+}
+
 impl MroDisplay for StructDef {
     fn min_width(&self) -> usize {
         0
@@ -609,6 +615,7 @@ impl MroDisplay for FiletypeHeader {
 mro_display_to_display! { FiletypeHeader }
 
 /// All the structs that need to be defined in an mro
+#[derive(Debug, Default)]
 pub struct StructHeader(BTreeMap<String, StructDef>);
 
 impl From<&StageMro> for StructHeader {
@@ -685,7 +692,13 @@ pub trait MroMaker {
     fn mro(adapter_name: impl ToString, stage_key: impl ToString) -> String {
         let stage_mro = Self::stage_mro(adapter_name, stage_key);
         let filetype = FiletypeHeader::from(&stage_mro);
-        format!("{}{}", filetype.to_string(), stage_mro.to_string())
+        let struct_header = StructHeader::from(&stage_mro);
+        format!(
+            "{}{}{}",
+            filetype.to_string(),
+            struct_header.to_string(),
+            stage_mro.to_string()
+        )
     }
     fn stage_name() -> String;
     fn stage_in_and_out() -> InAndOut;

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -13,6 +13,7 @@
 use crate::MartianVoid;
 use failure::{format_err, Error};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Write};
 use std::path::{Path, PathBuf};
@@ -172,6 +173,15 @@ mro_display_to_display! {MartianPrimaryType}
 pub enum MartianBlanketType {
     Primary(MartianPrimaryType),
     Array(MartianPrimaryType),
+}
+
+impl MartianBlanketType {
+    fn inner(&self) -> &MartianPrimaryType {
+        match *self {
+            MartianBlanketType::Primary(ref primary) => primary,
+            MartianBlanketType::Array(ref primary) => primary,
+        }
+    }
 }
 
 impl MroDisplay for MartianBlanketType {
@@ -476,6 +486,9 @@ pub struct InAndOut {
 }
 
 impl InAndOut {
+    fn iter_mro_fields(&self) -> impl Iterator<Item = &MroField> {
+        self.inputs.iter().chain(self.outputs.iter())
+    }
     fn retain_field_names(&self) -> Vec<String> {
         self.outputs
             .iter()
@@ -487,18 +500,10 @@ impl InAndOut {
 
 impl MroDisplay for InAndOut {
     fn min_width(&self) -> usize {
-        std::cmp::max(
-            self.inputs
-                .iter()
-                .map(|field| field.min_width())
-                .max()
-                .unwrap_or(0),
-            self.outputs
-                .iter()
-                .map(|field| field.min_width())
-                .max()
-                .unwrap_or(0),
-        )
+        self.iter_mro_fields()
+            .map(|field| field.min_width())
+            .max()
+            .unwrap_or(0)
     }
 
     fn mro_string_no_width(&self) -> String {
@@ -530,36 +535,26 @@ pub struct FiletypeHeader(HashSet<String>);
 
 impl From<&MroField> for FiletypeHeader {
     fn from(field: &MroField) -> FiletypeHeader {
-        let mut result = HashSet::new();
-        match field.ty {
-            MartianBlanketType::Primary(MartianPrimaryType::FileType(ref ext)) => {
-                result.insert(ext.to_string());
-            }
-            MartianBlanketType::Array(MartianPrimaryType::FileType(ref ext)) => {
-                result.insert(ext.to_string());
-            }
-            _ => {}
-        }
-        FiletypeHeader(result)
+        let mut result = FiletypeHeader(HashSet::new());
+        result.add_mro_field(field);
+        result
     }
 }
 
 impl From<&InAndOut> for FiletypeHeader {
     fn from(in_out: &InAndOut) -> FiletypeHeader {
-        let mut result = HashSet::new();
-        for field in in_out.inputs.iter().chain(in_out.outputs.iter()) {
-            result.extend(FiletypeHeader::from(field).0);
+        let mut result = FiletypeHeader(HashSet::new());
+        for field in in_out.iter_mro_fields() {
+            result.add_mro_field(field);
         }
-        FiletypeHeader(result)
+        result
     }
 }
 
 impl From<&StageMro> for FiletypeHeader {
     fn from(stage_mro: &StageMro) -> FiletypeHeader {
-        let mut result = FiletypeHeader::from(&stage_mro.stage_in_out);
-        if let Some(ref chunk_in_out) = stage_mro.chunk_in_out {
-            result.0.extend(FiletypeHeader::from(chunk_in_out).0)
-        }
+        let mut result = FiletypeHeader(HashSet::new());
+        result.add_stage(stage_mro);
         result
     }
 }
@@ -568,7 +563,22 @@ impl FiletypeHeader {
     /// Find out all the filetypes in the stage and add the extensions
     /// to the internal hashset which stores all the extensions
     pub fn add_stage(&mut self, stage_mro: &StageMro) {
-        self.0.extend(FiletypeHeader::from(stage_mro).0);
+        for field in stage_mro.iter_mro_fields() {
+            self.add_mro_field(field);
+        }
+    }
+    pub fn add_mro_field(&mut self, mro_field: &MroField) {
+        match mro_field.ty.inner() {
+            MartianPrimaryType::FileType(ref ext) => {
+                self.0.insert(ext.to_string());
+            }
+            MartianPrimaryType::Struct(ref def) => {
+                for field in &def.fields {
+                    self.add_mro_field(field);
+                }
+            }
+            _ => {}
+        }
     }
 }
 
@@ -599,7 +609,60 @@ impl MroDisplay for FiletypeHeader {
 mro_display_to_display! { FiletypeHeader }
 
 /// All the structs that need to be defined in an mro
-pub struct StructHeader(HashMap<String, StructDef>);
+pub struct StructHeader(BTreeMap<String, StructDef>);
+
+impl From<&StageMro> for StructHeader {
+    fn from(stage_mro: &StageMro) -> StructHeader {
+        let mut result = StructHeader(BTreeMap::new());
+        result.add_stage(stage_mro);
+        result
+    }
+}
+
+impl StructHeader {
+    /// Find out all the structs in the stage and add it to the
+    /// internal hashmap which stores all the structs
+    pub fn add_stage(&mut self, stage_mro: &StageMro) {
+        for field in stage_mro.iter_mro_fields() {
+            self.add_mro_field(field);
+        }
+    }
+    pub fn add_mro_field(&mut self, mro_field: &MroField) {
+        if let MartianPrimaryType::Struct(ref def) = mro_field.ty.inner() {
+            for field in &def.fields {
+                self.add_mro_field(field);
+            }
+            if self.0.contains_key(&def.name) {
+                assert_eq!(
+                    &self.0[&def.name], def,
+                    "struct {} has conflicting definitions.\nDefinition 1: {:?}\nDefinition 2: {:?}",
+                    def.name, &self.0[&def.name], def
+                );
+            } else {
+                self.0.insert(def.name.clone(), def.clone());
+            }
+        }
+    }
+}
+
+impl MroDisplay for StructHeader {
+    fn min_width(&self) -> usize {
+        0
+    }
+    fn mro_string_no_width(&self) -> String {
+        self.mro_string_with_width(self.min_width())
+    }
+    fn mro_string_with_width(&self, field_width: usize) -> String {
+        let mut result = String::new();
+
+        for struct_def in self.0.values() {
+            writeln!(&mut result, "{}", struct_def.mro_string(Some(field_width))).unwrap();
+        }
+        result
+    }
+}
+
+mro_display_to_display! {StructHeader, TAB_WIDTH_FOR_MRO}
 
 /// An object that can generate a `StageMro`
 ///
@@ -705,6 +768,13 @@ impl MroDisplay for StageMro {
 mro_display_to_display! {StageMro, TAB_WIDTH_FOR_MRO}
 
 impl StageMro {
+    fn iter_mro_fields(&self) -> impl Iterator<Item = &MroField> {
+        self.stage_in_out.iter_mro_fields().chain(
+            self.chunk_in_out
+                .iter()
+                .flat_map(|in_out| in_out.iter_mro_fields()),
+        )
+    }
     fn minified_chunk_in_outs(&self) -> Option<InAndOut> {
         match self.chunk_in_out {
             Some(ref chunk_in_out) => {
@@ -773,6 +843,7 @@ impl StageMro {
 mod tests {
     use super::*;
     use indoc::indoc;
+    use pretty_assertions::assert_eq;
     use MartianBlanketType::*;
     use MartianPrimaryType::*;
 
@@ -1165,6 +1236,20 @@ mod tests {
     }
 
     #[test]
+    fn test_filetype_header_from_struct() {
+        assert_eq!(
+            FiletypeHeader::from(&MroField::new(
+                "foo",
+                Primary(Struct(StructDef {
+                    name: "MexFiles".to_string(),
+                    fields: vec![MroField::new("foo", Array(FileType("txt".into())))],
+                }))
+            )),
+            FiletypeHeader(vec!["txt".to_string()].into_iter().collect())
+        );
+    }
+
+    #[test]
     fn test_filetype_header_from_in_out() {
         let filetype = FiletypeHeader::from(&InAndOut {
             inputs: vec![
@@ -1292,5 +1377,105 @@ mod tests {
         "#
         );
         assert_eq!(struct_def.to_string(), expected);
+    }
+
+    #[test]
+    fn test_struct_header_display() {
+        let struct_def = StructDef {
+            name: "MexFiles".to_string(),
+            fields: vec![
+                MroField::new("matrix", Primary(FileType("mtx".into()))),
+                MroField::new("barcodes", Primary(Path)),
+                MroField::new("features", Primary(Path)),
+            ],
+        };
+        let mut map = BTreeMap::new();
+        map.insert(struct_def.name.clone(), struct_def);
+        let header = StructHeader(map);
+
+        let expected = indoc!(
+            r#"
+            struct MexFiles(
+                mtx  matrix,
+                path barcodes,
+                path features,
+            )
+
+        "#
+        );
+        assert_eq!(header.to_string(), expected);
+    }
+
+    #[test]
+    fn test_struct_header_recursive_display() {
+        let sample_def = StructDef {
+            name: "SampleDef".into(),
+            fields: vec![MroField::new("read_path", Primary(Path))],
+        };
+        let chemistry_def = StructDef {
+            name: "ChemistryDef".into(),
+            fields: vec![
+                MroField::new("name", Primary(Str)),
+                MroField::new("barcode_read", Primary(Str)),
+                MroField::new("barcode_length", Primary(Int)),
+            ],
+        };
+        let rna_chunk = StructDef {
+            name: "RnaChunk".to_string(),
+            fields: vec![
+                MroField::new("chemistry_def", Primary(Struct(chemistry_def.clone()))),
+                MroField::new("chunk_id", Primary(Int)),
+                MroField::new("r1", Primary(FileType("fastq.gz".into()))),
+            ],
+        };
+
+        let stage_mro = StageMro {
+            stage_name: "SETUP_CHUNKS".into(),
+            adapter_name: "my_adapter".into(),
+            stage_key: "setup_chunks".into(),
+            stage_in_out: InAndOut {
+                inputs: vec![
+                    MroField::new("sample_defs", Array(Struct(sample_def))),
+                    MroField::new(
+                        "custom_chemistry_def",
+                        Primary(Struct(chemistry_def.clone())),
+                    ),
+                ],
+                outputs: vec![
+                    MroField::new("read_chunks", Array(Struct(rna_chunk))),
+                    MroField::new("chemistry_def", Primary(Struct(chemistry_def))),
+                ],
+            },
+            chunk_in_out: None,
+            using_attrs: MroUsing::default(),
+        };
+        stage_mro.verify();
+
+        assert_eq!(
+            FiletypeHeader::from(&stage_mro),
+            FiletypeHeader(vec!["fastq.gz".into()].into_iter().collect())
+        );
+
+        let expected = indoc!(
+            r#"
+            struct ChemistryDef(
+                string name,
+                string barcode_read,
+                int    barcode_length,
+            )
+
+            struct RnaChunk(
+                ChemistryDef chemistry_def,
+                int          chunk_id,
+                fastq.gz     r1,
+            )
+
+            struct SampleDef(
+                path read_path,
+            )
+
+        "#
+        );
+        assert_eq!(StructHeader::from(&stage_mro).to_string(), expected);
     }
 }


### PR DESCRIPTION
Now we can write code like this:
```
#[derive(Serialize, Deserialize, MartianStruct)]
struct RnaChunk { chunk_id: u8 }

#[derive(Serialize, Deserialize, MartianStruct)]
struct SampleDef { read_path: PathBuf }

#[derive(Serialize, Deserialize, MartianStruct)]
struct SI { sample_def: SampleDef }

#[derive(Serialize, Deserialize, MartianStruct)]
struct SO { chunks: Vec<RnaChunk> }

pub struct SetupChunks;

#[make_mro]
impl MartianMain for SetupChunks {
    type StageInputs = SI;
    type StageOutputs = SO;
    fn main(&self, _: Self::StageInputs, _: MartianRover) -> Result<Self::StageOutputs, Error> {
        unimplemented!()
    }
}
```

which would produce the following mro:

```
struct RnaChunk(
    int chunk_id,
)

struct SampleDef(
    path read_path,
)

stage SETUP_CHUNKS(
    in  SampleDef  sample_def,
    out RnaChunk[] chunks,
    src comp       "my_adapter martian setup_chunks",
)

```
