### PR TITLE
print out nested structs in correct order that can be compiled by martian

### DIFF
--- a/martian-derive/tests/mro/test_struct.mro
+++ b/martian-derive/tests/mro/test_struct.mro
@@ -8,10 +8,8 @@
 filetype fastq;
 filetype json;
 
-struct ChemistryDef(
-    string name,
-    string barcode_read,
-    int    barcode_length,
+struct SampleDef(
+    path read_path,
 )
 
 struct Config(
@@ -21,14 +19,16 @@ struct Config(
     json        primers,
 )
 
+struct ChemistryDef(
+    string name,
+    string barcode_read,
+    int    barcode_length,
+)
+
 struct RnaChunk(
     ChemistryDef chemistry_def,
     int          chunk_id,
     fastq        r1,
-)
-
-struct SampleDef(
-    path read_path,
 )
 
 stage SETUP_CHUNKS(

--- a/martian-filetypes/benches/benchmarks.rs
+++ b/martian-filetypes/benches/benchmarks.rs
@@ -56,7 +56,7 @@ where
             })
         })
         .sample_size(10)
-        .throughput(Throughput::Elements(data.len() as u32)),
+        .throughput(Throughput::Elements(data.len() as u64)),
     );
 }
 
@@ -99,7 +99,7 @@ where
                 })
             })
             .sample_size(10)
-            .throughput(Throughput::Elements(elements)),
+            .throughput(Throughput::Elements(elements.into())),
     );
 }
 

--- a/martian-filetypes/src/bin_file.rs
+++ b/martian-filetypes/src/bin_file.rs
@@ -62,7 +62,7 @@
 //!     // Note that the bincode files **will not be identical** in the two cases.
 //!     // let vals: Vec<_> = (0..10_000).into_iter().collect()
 //!     // bin_file.write(&vals)?;
-//!     
+//!
 //!     // Type inference engine should figure out the type automatically,
 //!     // but it is shown here for illustration.
 //!     let mut reader: LazyBincodeReader<i32> = bin_file.lazy_reader()?;

--- a/martian-filetypes/src/json_file.rs
+++ b/martian-filetypes/src/json_file.rs
@@ -62,7 +62,7 @@
 //!     // Both approaches will give you an identical json file.
 //!     // let vals: Vec<_> = (0..10_000).into_iter().collect()
 //!     // json_file.write(&vals)?;
-//!     
+//!
 //!     let mut reader: LazyJsonReader<i32> = json_file.lazy_reader()?;
 //!     let mut max_val = 0;
 //!     // reader is an `Iterator` over values of type Result<`i32`, Error>

--- a/martian-filetypes/src/lz4_file.rs
+++ b/martian-filetypes/src/lz4_file.rs
@@ -28,7 +28,7 @@
 //!     let decoded: Chemistry = lz4_json_file.read()?;
 //!     assert_eq!(chem, decoded);
 //!     # std::fs::remove_file(lz4_json_file)?; // Remove the file (hidden from the doc)
-//!     
+//!
 //!     // --------------------- Bincode ----------------------------------
 //!     let lz4_bin_file: Lz4<BincodeFile> = Lz4::from("example"); // example.bincode.lz4
 //!     // Need to explcitly annotate the type id you are using from() or MartianFileType::new()
@@ -72,7 +72,7 @@
 //!
 //!     // For this extreme case of compression, the output file will be just 194 bytes, as opposed to
 //!     // 39KB uncompressed
-//!     
+//!
 //!     let mut lz4_reader = lz4_bin_file.lazy_reader()?;
 //!     // The type of the lz4_reader will be inferred by the compiler as:
 //!     // LazyLz4Reader<LazyBincodeReader<i32, lz4::decoder::Decoder<BufReader<File>>>, i32, BufReader<File>>

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -2,7 +2,7 @@ use std;
 use std::collections::HashSet;
 use std::fs::{rename, File, OpenOptions};
 use std::io::{Read, Write};
-use std::os::unix::io::{IntoRawFd, FromRawFd};
+use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::path::PathBuf;
 
 use crate::write_errors;
@@ -200,7 +200,7 @@ impl Metadata {
     /// Write to _log
     pub fn log(&mut self, level: &str, message: &str) -> Result<()> {
         let mut log_file = unsafe { File::from_raw_fd(3) };
-        
+
         log_file
             .write(&format!("{} [{}] {}", make_timestamp_now(), level, message).as_bytes())
             .and(log_file.flush())?;

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -624,8 +624,7 @@ mro_display_to_display! { FiletypeHeader }
 
 /// All the structs that need to be defined in an mro
 #[derive(Debug, Default)]
-pub struct StructHeader(BTreeMap<String, (StructDef, usize)>);  // key = struct name, val = (struct def, insertion index)
-
+pub struct StructHeader(BTreeMap<String, (StructDef, usize)>); // key = struct name, val = (struct def, insertion index)
 
 impl From<&StageMro> for StructHeader {
     fn from(stage_mro: &StageMro) -> StructHeader {
@@ -676,7 +675,12 @@ impl MroDisplay for StructHeader {
         struct_defs.sort_by_key(|x| x.1);
 
         for struct_def in struct_defs.iter() {
-            writeln!(&mut result, "{}", struct_def.0.mro_string(Some(field_width))).unwrap();
+            writeln!(
+                &mut result,
+                "{}",
+                struct_def.0.mro_string(Some(field_width))
+            )
+            .unwrap();
         }
         result
     }
@@ -1418,7 +1422,7 @@ mod tests {
             ],
         };
         let mut map = BTreeMap::new();
-        map.insert(struct_def.name.clone(), (struct_def,0));
+        map.insert(struct_def.name.clone(), (struct_def, 0));
         let header = StructHeader(map);
 
         let expected = indoc!(

--- a/martian/src/prelude.rs
+++ b/martian/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::stage::{
     MartianFileType, MartianMain, MartianMakePath, MartianRover, MartianStage, MartianVoid,
     RawMartianStage, Resource, StageDef,
 };
-pub use crate::{MartianAdapter, martian_make_mro};
+pub use crate::{martian_make_mro, MartianAdapter};
 pub use failure::Error;
 pub use log::LevelFilter;
 pub use martian_stages;

--- a/martian/src/stage.rs
+++ b/martian/src/stage.rs
@@ -1,7 +1,7 @@
+use crate::metadata::Metadata;
 use crate::metadata::Version;
 use crate::mro::{MartianStruct, MroMaker};
 use crate::utils::{obj_decode, obj_encode};
-use crate::metadata::Metadata;
 use failure::{Error, ResultExt};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -619,7 +619,6 @@ where
         StageKind::MainOnly
     }
 }
-
 
 impl<T> RawMartianStage for T
 where


### PR DESCRIPTION
Fixes the behavior of nested structs so that the inner structs are always printed before the outer structs. Fixes a unit test (test_struct.mro) that previously passed but the test itself was not valid compiling martian because of this issue.