### PR TITLE
add staticlib crate type

### DIFF
--- a/cargo-martian/src/metadata.rs
+++ b/cargo-martian/src/metadata.rs
@@ -36,6 +36,8 @@ pub enum Kind {
     Lib,
     #[serde(rename = "proc-macro")]
     ProcMacro,
+    #[serde(rename = "staticlib")]
+    StaticLib,
 }
 
 impl Metadata {


### PR DESCRIPTION
Expand cargo-martian to support `staticlib` crate types in the workspace.