### PR TITLE
fix order of entries in using block

### DIFF
--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -106,8 +106,8 @@ pub fn make_mro(
         fn using_attributes() -> ::martian::MroUsing {
             ::martian::MroUsing {
                 #mem_gb_quote
-                #vmem_gb_quote
                 #threads_quote
+                #vmem_gb_quote
                 #volatile_quote
                 ..Default::default()
             }


### PR DESCRIPTION
`mrf` sorts the entries in the `using` block lexicographically. So the entries should read
```
using(
    mem_gb = ...
    threads = ...
    vmem_gb = ...
    volatile = ...
)
```