### PR TITLE
fix order of using attributes

### DIFF
--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -490,7 +490,7 @@ macro_rules! mro_using {
     };
 }
 
-mro_using! {mem_gb: i16, vmem_gb: i16, threads: i16, volatile: Volatile}
+mro_using! {mem_gb: i16, threads: i16, vmem_gb: i16, volatile: Volatile}
 
 /// Input and outputs fields together
 #[derive(Debug, Default)]


### PR DESCRIPTION
My [last PR](https://github.com/martian-lang/martian-rust/pull/33) didn't actually fix the issue (I had just re-ordered the fields in a struct definition). This actually fixes the bug and I verified that it does.

Now the auto-generated MRO by `make_mro` is sorted as
```
using(
    mem_gb = ...
    threads = ...
    vmem_gb = ...
    volatile = ...
)
```

