### PR TITLE
Add profile_mode to JobInfo

### DIFF
--- a/martian-derive/Cargo.toml
+++ b/martian-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-derive"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 include = ["src/lib.rs", "README.md"]

--- a/martian-filetypes/Cargo.toml
+++ b/martian-filetypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-filetypes"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Sreenath Krishnan <sreenathk.89@gmail.com>"]
 edition = "2018"
 include = ["src/**/*"]

--- a/martian/Cargo.toml
+++ b/martian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 include = ["src/**/*", "README.md"]

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -63,6 +63,7 @@ impl Default for Version {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ProfileMode {
     Disable,
     Cpu,

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -42,6 +42,8 @@ pub struct JobInfo {
     #[serde(rename = "vmemGB")]
     pub vmem_gb: usize,
     pub version: Version,
+    #[serde(default)]
+    pub profile_mode: ProfileMode,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,6 +58,22 @@ impl Default for Version {
             martian: "unknown".into(),
             pipelines: "unknown".into(),
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProfileMode {
+    Disable,
+    Cpu,
+    Line,
+    Mem,
+    Perf,
+}
+
+impl Default for ProfileMode {
+    fn default() -> ProfileMode {
+        ProfileMode::Disable
     }
 }
 


### PR DESCRIPTION
- First step towards enabling in-built profiling
- In subsequent PRs we can play around with pretty trace based profiling when the `profile_mode` is `cpu`