### PR TITLE
format logging messages by default like martian

### DIFF
--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -66,7 +66,7 @@ fn setup_logging(log_file: File, level: LevelFilter) {
     let logger_config = fern::Dispatch::new()
         .format(|out, msg, record| {
             let time_str = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-            out.finish(format_args!("[{}][{}] {}", time_str, record.level(), msg))
+            out.finish(format_args!("{} [{}] {}", time_str, record.target(), msg))
         })
         .chain(log_file)
         .chain(io::stdout());


### PR DESCRIPTION
Martian's built-in format is `{TIMESTAMP} [{TARGET}] {MESSAGE}`, not sure we care about reporting loglevel here.

Otherwise you get differences like:
```
2021-05-30 10:25:59 [time] __start__
2021-05-30 10:25:59 [monitor] cgroup memory limit of 9223372036854771712 bytes detected
[2021-05-30 10:26:05][INFO] computing k-nearest neighbors with k = 477
```