### PR TITLE
Add Ability to Disable Stages in mro macros

### DIFF
--- a/book/_sidebar.md
+++ b/book/_sidebar.md
@@ -7,6 +7,7 @@
 * [Stage Traits](content/stage.md)
 * [Associated types](content/associated_types.md)
 * [Chunks & Resources](content/resource.md)
+* [Disabling Stages](content/disabling.md)
 * [Unit Testing stages](content/testing.md)
 * [WIP Dealing with filetypes]()
 * [WIP Macros]()

--- a/book/content/disabling.md
+++ b/book/content/disabling.md
@@ -1,0 +1,23 @@
+# Disabling a Stage
+
+
+A stage can be disabled by specifiying a boolean flag in the `using` section of the mro. For example:
+
+```mro
+stage MY_STAGE(
+...
+) using (
+    disabled  = self.no_bam,
+)
+```
+
+Since we will be auto-generating the mro, we should not be editing the mro directly. Instead we should modify the proc-macro attribute `#[make_mro]` to include the disabled flag. i.e:
+
+```rust
+#[make_mro(disabled=self.nobam)]
+impl MartianStage for MyStage {
+......
+}
+```
+
+Note that the text after disabled will be output directly and can refer to any value that will be used in the pipeline and must be set based on your knowledge of the pipeline.  If a stage is used in multiple pipelines, the `disabled` variable should be available in both.

--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -26,7 +26,7 @@ const INVALID_MRO_TYPE_ERROR: &str = r#""The usage of mro_type should be of form
 /// a stage struct, it derives the trait `MroMaker` to the stage struct, which lets you generate
 /// the mro corresponding to the stage.
 ///
-/// You can optionally specify `mem_gb`, `threads`, `vmem_gb` and `volatile` within this proc-macro.
+/// You can optionally specify `mem_gb`, `threads`, `vmem_gb`, `disable`, and `volatile` within this proc-macro.
 /// For example, use `#[make_mro(mem_gb = 4, threads = 2]` for setting `mem_gb` and `threads` that would
 /// appear in the `using()` section of the mro definition.
 ///
@@ -102,6 +102,7 @@ pub fn make_mro(
         },
         None => quote![volatile: None,],
     };
+    let disabled_quote = parsed_attr.disabled.map(|x| quote![disabled:Some(String::from(#x)),]).unwrap_or(quote![]);
     let using_attributes_fn = quote![
         fn using_attributes() -> ::martian::MroUsing {
             ::martian::MroUsing {
@@ -109,6 +110,7 @@ pub fn make_mro(
                 #threads_quote
                 #vmem_gb_quote
                 #volatile_quote
+                #disabled_quote
                 ..Default::default()
             }
         }
@@ -335,7 +337,7 @@ macro_rules! attr_parse {
             type Err = String;
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 // When we specify negative values, for e.g #[make_mro(threads = -4)]
-                // casting the attribute Tokenstream to String intoduces an additional
+                // casting the attribute Tokenstream to String introduces an additional
                 // space after `-`, i.e we get "threads=- 4". So we get rid of the
                 // whitespaces here
                 let s: String = s.split_whitespace().collect();
@@ -375,6 +377,7 @@ attr_parse!(
     threads: i16,
     vmem_gb: i16,
     volatile: Volatile,
+    disabled: String,
     stage_name: String
 );
 

--- a/martian-derive/tests/mro/test_main_only.mro
+++ b/martian-derive/tests/mro/test_main_only.mro
@@ -9,6 +9,7 @@ stage SUM_SQUARES(
     out float   sum_sq,
     src comp    "adapter martian sum_squares",
 ) using (
-    mem_gb  = 4,
-    threads = 2,
+    mem_gb   = 4,
+    threads  = 2,
+    disabled = UPSTREAM_STAGE.disabled,
 )

--- a/martian-derive/tests/test_full_mro.rs
+++ b/martian-derive/tests/test_full_mro.rs
@@ -30,7 +30,7 @@ fn test_main_only() {
     }
     pub struct SumSquares;
 
-    #[make_mro(mem_gb = 4, threads = 2)]
+    #[make_mro(mem_gb = 4, threads = 2, disabled=UPSTREAM_STAGE.disabled)]
     impl MartianMain for SumSquares {
         type StageInputs = SumSquaresStageInputs;
         type StageOutputs = SumSquaresStageOutputs;
@@ -60,6 +60,7 @@ fn test_main_only() {
     //             mem_gb: Some(4i16),
     //             threads: Some(2i16),
     //             volatile: None,
+    //             disabled: Some("UPSTREAM_STAGE.disabled"),
     //             ..Default::default()
     //         }
     //     }

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -477,7 +477,7 @@ macro_rules! mro_using {
         ///     threads = 16,
         /// )
         /// ```
-        #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+        #[derive(Debug, Default, Clone, Serialize, Deserialize)]
         pub struct MroUsing {
             $(pub $property: Option<$type>,)*
         }
@@ -513,7 +513,7 @@ macro_rules! mro_using {
                     return result;
                 }
                 $(
-                    if let Some($property) = self.$property {
+                    if let Some(ref $property) = self.$property {
                         writeln!(
                             &mut result,
                             "{key:<width$} = {value},",
@@ -530,7 +530,7 @@ macro_rules! mro_using {
     };
 }
 
-mro_using! {mem_gb: i16, threads: i16, vmem_gb: i16, volatile: Volatile}
+mro_using! {mem_gb: i16, threads: i16, vmem_gb: i16, volatile: Volatile, disabled: String}
 
 /// Input and outputs fields together
 #[derive(Debug, Default)]
@@ -995,6 +995,19 @@ mod tests {
             indoc!(
                 "
                 threads    = 2,
+            "
+            )
+        );
+
+        assert_eq!(
+            MroUsing {
+                disabled: Some(String::from("self.disabled")),
+                ..Default::default()
+            }
+            .mro_string_no_width(),
+            indoc!(
+                "
+                disabled = self.disabled,
             "
             )
         );


### PR DESCRIPTION
Allows users to specify a boolean variable that can be used to disable their stage.