### PR TITLE
Replace `failure` with `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,28 +348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fern"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,12 +518,11 @@ dependencies = [
 
 [[package]]
 name = "martian"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
+ "anyhow",
  "backtrace",
  "chrono",
- "failure",
- "failure_derive",
  "fern",
  "heck",
  "indoc",
@@ -553,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "martian-derive"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "martian",
  "pretty_assertions",
@@ -566,12 +552,12 @@ dependencies = [
 
 [[package]]
 name = "martian-filetypes"
-version = "0.23.0"
+version = "0.25.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "criterion",
  "csv",
- "failure",
  "flate2",
  "lz4",
  "martian",
@@ -587,8 +573,8 @@ dependencies = [
 name = "martian-lab"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "docopt",
- "failure",
  "martian",
  "martian-derive",
  "serde",
@@ -1038,18 +1024,6 @@ checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -26,10 +26,7 @@ yanked = "warn"
 notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-ignore = [
-    "RUSTSEC-2019-0036",  # TODO: get off of `failure`
-    "RUSTSEC-2020-0036",  # TODO: get off of `failure`
-]
+ignore = []
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:

--- a/martian-derive/Cargo.toml
+++ b/martian-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-derive"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 include = ["src/lib.rs", "README.md"]

--- a/martian-filetypes/Cargo.toml
+++ b/martian-filetypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-filetypes"
-version = "0.23.0"
+version = "0.25.0"
 authors = ["Sreenath Krishnan <sreenathk.89@gmail.com>"]
 edition = "2018"
 include = ["src/**/*"]
@@ -14,7 +14,7 @@ martian-derive = { path = "../martian-derive" }
 serde = { version = '1.0', features = ['derive'] }
 serde_json = "*"
 bincode = "1.3"
-failure = "*"
+anyhow = { version = "1", features = ["backtrace"] }
 lz4 = "1.23"
 csv = { version = "1.1.1" }
 flate2 = "1"

--- a/martian-filetypes/src/bin_file.rs
+++ b/martian-filetypes/src/bin_file.rs
@@ -80,7 +80,7 @@
 //! ```
 
 use crate::{FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
-use failure::format_err;
+use anyhow::format_err;
 use martian::{Error, MartianFileType};
 use martian_derive::martian_filetype;
 use serde::de::DeserializeOwned;

--- a/martian-filetypes/src/json_file.rs
+++ b/martian-filetypes/src/json_file.rs
@@ -78,7 +78,7 @@
 //! ```
 
 use crate::{FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
-use failure::format_err;
+use anyhow::format_err;
 use martian::Error;
 use martian::MartianFileType;
 use martian_derive::martian_filetype;

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -35,7 +35,7 @@
 //! ```
 
 use crate::{FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
-use failure::format_err;
+use anyhow::format_err;
 use martian::{Error, MartianFileType};
 use martian_derive::martian_filetype;
 use serde::de::DeserializeOwned;

--- a/martian-filetypes/tests/ui/invalid_type_read.rs
+++ b/martian-filetypes/tests/ui/invalid_type_read.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Error;
 use martian_derive::martian_filetype;
 use martian_filetypes::bin_file::BinaryFormat;
 use martian_filetypes::json_file::JsonFormat;

--- a/martian-filetypes/tests/ui/invalid_type_write.rs
+++ b/martian-filetypes/tests/ui/invalid_type_write.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Error;
 use martian_derive::martian_filetype;
 use martian_filetypes::bin_file::BinaryFormat;
 use martian_filetypes::json_file::JsonFormat;

--- a/martian-lab/Cargo.toml
+++ b/martian-lab/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ['derive'] }
 martian = { path = "../martian" }
 martian-derive = { path = "../martian-derive" }
 docopt = "1.0"
-failure = "*"
+anyhow = "1"
 
 [[example]]
 name = "sum_sq"

--- a/martian-lab/examples/sum_sq/Cargo.toml
+++ b/martian-lab/examples/sum_sq/Cargo.toml
@@ -12,4 +12,4 @@ docopt = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 martian = {git = "https://github.com/martian-lang/martian-rust.git"}
 martian-derive = {git = "https://github.com/martian-lang/martian-rust.git"}
-failure = "*"
+anyhow = "1"

--- a/martian-lab/examples/sum_sq/src/sum_squares.rs
+++ b/martian-lab/examples/sum_sq/src/sum_squares.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 // The prelude brings the following items in scope:
 // - Traits: MartianMain, MartianStage, RawMartianStage, MartianFileType, MartianMakePath
 // - Struct/Enum: MartianRover, Resource, StageDef, MartianVoid,
-//                Error (from failure crate), LevelFilter (from log crate)
+//                Error (from anyhow crate), LevelFilter (from log crate)
 // - Macros: martian_stages!
 // - Functions: martian_main, martian_main_with_log_level, martian_make_mro
 use martian::prelude::*;
@@ -89,7 +89,7 @@ impl MartianStage for SumSquares {
             // let the other chunks finish
             let dur = std::time::Duration::new(3, 0);
             std::thread::sleep(dur);
-            return Err(failure::format_err!("hit special failure value"));
+            return Err(anyhow::anyhow!("hit special failure value"));
         }
 
         Ok(SumSquaresChunkOutputs {

--- a/martian-lab/tests/error_test/expected/SUM_SQUARES/SUM_SQUARES/fork0/chnk3/_stackvars
+++ b/martian-lab/tests/error_test/expected/SUM_SQUARES/SUM_SQUARES/fork0/chnk3/_stackvars
@@ -1,33 +1,31 @@
-   0: failure::backtrace::internal::InternalBacktrace::new
-             at /mnt/bazelbuild/user/sreenath.krishnan/cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/backtrace/internal.rs:46
-   1: failure::backtrace::Backtrace::new
-             at /mnt/bazelbuild/user/sreenath.krishnan/cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/backtrace/mod.rs:121
-   2: <failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from
-             at /mnt/bazelbuild/user/sreenath.krishnan/cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/error/error_impl.rs:19
-   3: <failure::error::Error as core::convert::From<F>>::from
-             at /mnt/bazelbuild/user/sreenath.krishnan/cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/error/mod.rs:36
-   4: failure::error_message::err_msg
-             at /mnt/bazelbuild/user/sreenath.krishnan/cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/error_message.rs:12
-   5: <sum_sq::sum_squares::SumSquares as martian::stage::MartianStage>::main
+   0: <sum_sq::sum_squares::SumSquares as martian::stage::MartianStage>::main
              at /mnt/home/sreenath.krishnan/codes/martian-rust/martian-lab/examples/sum_sq/src/sum_squares.rs:94
-   6: <T as martian::stage::RawMartianStage>::main
+   1: <T as martian::stage::RawMartianStage>::main
              at /mnt/home/sreenath.krishnan/codes/martian-rust/martian/src/stage.rs:644
-   7: martian::martian_entry_point
+   2: martian::martian_entry_point
              at /mnt/home/sreenath.krishnan/codes/martian-rust/martian/src/lib.rs:225
-   8: martian::MartianAdapter<S>::run_get_error
+   3: martian::MartianAdapter<S>::run_get_error
              at /mnt/home/sreenath.krishnan/codes/martian-rust/martian/src/lib.rs:131
-   9: martian::MartianAdapter<S>::run
+   4: martian::MartianAdapter<S>::run
              at /mnt/home/sreenath.krishnan/codes/martian-rust/martian/src/lib.rs:124
-  10: sum_sq::main
+   5: sum_sq::main
              at /mnt/home/sreenath.krishnan/codes/martian-rust/martian-lab/examples/sum_sq/src/main.rs:48
-  11: core::ops::function::FnOnce::call_once
+   6: core::ops::function::FnOnce::call_once
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/core/src/ops/function.rs:227
-  12: std::sys_common::backtrace::__rust_begin_short_backtrace
+   7: std::sys_common::backtrace::__rust_begin_short_backtrace
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/sys_common/backtrace.rs:137
-  13: std::rt::lang_start::{{closure}}
+   8: std::rt::lang_start::{{closure}}
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:66
-  14: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
+   9: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/core/src/ops/function.rs:259
+      std::panicking::try::do_call
+             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:373
+      std::panicking::try
+             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:337
+      std::panic::catch_unwind
+             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:379
+      std::rt::lang_start_internal::{{closure}}
+             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:51
       std::panicking::try::do_call
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:373
       std::panicking::try
@@ -36,8 +34,8 @@
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:379
       std::rt::lang_start_internal
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:51
-  15: std::rt::lang_start
+  10: std::rt::lang_start
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:65
-  16: main
-  17: __libc_start_main
-  18: <unknown>
+  11: main
+  12: __libc_start_main
+  13: <unknown>

--- a/martian-lab/tests/error_test/expected/SUM_SQUARES/SUM_SQUARES/fork0/chnk3/_stackvars
+++ b/martian-lab/tests/error_test/expected/SUM_SQUARES/SUM_SQUARES/fork0/chnk3/_stackvars
@@ -24,14 +24,6 @@
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:337
       std::panic::catch_unwind
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:379
-      std::rt::lang_start_internal::{{closure}}
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:51
-      std::panicking::try::do_call
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:373
-      std::panicking::try
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:337
-      std::panic::catch_unwind
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:379
       std::rt::lang_start_internal
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:51
   10: std::rt::lang_start

--- a/martian/Cargo.toml
+++ b/martian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 include = ["src/*.rs", "README.md"]
@@ -14,8 +14,7 @@ chrono = { version = "*", default-features = false, features = ["std", "clock"] 
 serde = { version = "1.0", features = ['derive'] }
 serde_json = "1.0"
 backtrace = "*"
-failure = "*"
-failure_derive = "*"
+anyhow = { version = "1", features = ["backtrace"] }
 heck = "*"
 tempfile = "3"
 rustc_version = ">=0.3, <0.5"

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -18,7 +18,8 @@ use backtrace::Backtrace;
 use chrono::Local;
 use log::{error, info};
 
-pub use failure::{format_err, Error, ResultExt};
+pub use anyhow::Error;
+use anyhow::{format_err, Context};
 
 mod metadata;
 pub use metadata::*;
@@ -156,7 +157,7 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
         Ok(m) => m,
         Err(e) => {
             let _ = write_errors(&format!("{:?}", e), false);
-            return (1, Some(e.into()));
+            return (1, Some(e));
         }
     };
 
@@ -236,9 +237,7 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
         // write message and stack trace, exit code = 1;
         Err(e) => {
             let bt = e.backtrace();
-            if !bt.is_empty() {
-                let _ = md.stackvars(&bt.to_string());
-            }
+            let _ = md.stackvars(&bt.to_string());
             let _ = write_errors(&format!("{}", e), is_error_assert(&e));
             (1, Some(e))
         }

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -10,8 +10,8 @@
 //! - Attributes (mem_gb, vmem_gb, threads, volatile etc.)
 //!
 
-use crate::MartianVoid;
-use failure::{format_err, Error};
+use crate::{Error, MartianVoid};
+use anyhow::format_err;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::collections::{HashMap, HashSet};

--- a/martian/src/prelude.rs
+++ b/martian/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::stage::{
     MartianFileType, MartianMain, MartianMakePath, MartianRover, MartianStage, MartianVoid,
     RawMartianStage, Resource, StageDef,
 };
+pub use crate::Error;
 pub use crate::{martian_make_mro, MartianAdapter};
-pub use failure::Error;
 pub use log::LevelFilter;
 pub use martian_stages;

--- a/martian/src/utils.rs
+++ b/martian/src/utils.rs
@@ -2,8 +2,7 @@
 //!
 //! All the functions are simple wrappers around functions from
 //! other crates.
-use crate::{Json, JsonDict};
-use failure::Error;
+use crate::{Error, Json, JsonDict};
 use serde::Serialize;
 use std::path::Path;
 use std::path::PathBuf;


### PR DESCRIPTION
`failure` is [deprecated](https://github.com/rust-lang-deprecated/failure#failure---a-new-error-management-story). `anyhow` is a recommended replacement for `failure::Error`, including backtraces (with the `backtrace` feature).