### PR TITLE
Reduce duplicated generated code.

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,4 +8,4 @@ jobs:
     - uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features --all-targets -- -W clippy::wildcard_imports -W clippy::float_cmp
+        args: --all-features --all-targets -- -W clippy::wildcard_imports

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.54.0
+        toolchain: 1.55.0
         components: rustfmt
     - name: Print cargo version
-      run: rustup default 1.54.0 && cargo --version
+      run: rustup default 1.55.0 && cargo --version
     - uses: actions/checkout@v2
     - name: Check Rust formatting
       run: cargo fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "martian"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,9 @@ yanked = "warn"
 notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-ignore = []
+ignore = [
+    "RUSTSEC-2020-0159",  # TODO: upgrade when possible, or find an alternative.
+]
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:

--- a/martian-derive/tests/test_full_mro.rs
+++ b/martian-derive/tests/test_full_mro.rs
@@ -499,6 +499,7 @@ fn test_typed_map() {
         map_of_lists: HashMap<String, Vec<usize>>,
         map_of_matrices: HashMap<String, Vec<Vec<usize>>>,
         vec_of_maps: Vec<HashMap<String, FastqFile>>,
+        #[allow(clippy::type_complexity)]
         ludicrous_map: Option<Vec<Vec<HashMap<String, Vec<Vec<FastqFile>>>>>>,
     }
 

--- a/martian-derive/tests/ui_martian_struct/test_invalid_mro_type_val.stderr
+++ b/martian-derive/tests/ui_martian_struct/test_invalid_mro_type_val.stderr
@@ -11,12 +11,16 @@ error[E0425]: cannot find value `int` in this scope
   |                ^^^ not found in this scope
 
 error[E0277]: the trait bound `Foo: MartianFileType` is not satisfied
- --> $DIR/test_invalid_mro_type_val.rs:5:10
-  |
-5 | #[derive(MartianStruct)]
-  |          ^^^^^^^^^^^^^ the trait `MartianFileType` is not implemented for `Foo`
-  |
-  = note: required because of the requirements on the impl of `AsMartianPrimaryType` for `Foo`
-  = note: required because of the requirements on the impl of `AsMartianBlanketType` for `Foo`
-  = note: required by `as_martian_blanket_type`
-  = note: this error originates in the derive macro `MartianStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $DIR/test_invalid_mro_type_val.rs:5:10
+    |
+5   | #[derive(MartianStruct)]
+    |          ^^^^^^^^^^^^^ the trait `MartianFileType` is not implemented for `Foo`
+    |
+    = note: required because of the requirements on the impl of `AsMartianPrimaryType` for `Foo`
+    = note: required because of the requirements on the impl of `AsMartianBlanketType` for `Foo`
+note: required by `as_martian_blanket_type`
+   --> $DIR/mro.rs:275:5
+    |
+275 |     fn as_martian_blanket_type() -> MartianBlanketType;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in the derive macro `MartianStruct` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/martian-derive/tests/ui_martian_struct/test_missing_martian_type.stderr
+++ b/martian-derive/tests/ui_martian_struct/test_missing_martian_type.stderr
@@ -1,10 +1,14 @@
 error[E0277]: the trait bound `Foo: MartianFileType` is not satisfied
- --> $DIR/test_missing_martian_type.rs:5:10
-  |
-5 | #[derive(MartianStruct)]
-  |          ^^^^^^^^^^^^^ the trait `MartianFileType` is not implemented for `Foo`
-  |
-  = note: required because of the requirements on the impl of `AsMartianPrimaryType` for `Foo`
-  = note: required because of the requirements on the impl of `AsMartianBlanketType` for `Foo`
-  = note: required by `as_martian_blanket_type`
-  = note: this error originates in the derive macro `MartianStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $DIR/test_missing_martian_type.rs:5:10
+    |
+5   | #[derive(MartianStruct)]
+    |          ^^^^^^^^^^^^^ the trait `MartianFileType` is not implemented for `Foo`
+    |
+    = note: required because of the requirements on the impl of `AsMartianPrimaryType` for `Foo`
+    = note: required because of the requirements on the impl of `AsMartianBlanketType` for `Foo`
+note: required by `as_martian_blanket_type`
+   --> $DIR/mro.rs:275:5
+    |
+275 |     fn as_martian_blanket_type() -> MartianBlanketType;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in the derive macro `MartianStruct` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/martian-filetypes/Cargo.toml
+++ b/martian-filetypes/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-martian = { path = "../martian" }
+martian = { version = ">=0.25.1", path = "../martian" }
 martian-derive = { path = "../martian-derive" }
 serde = { version = '1.0', features = ['derive'] }
 serde_json = "*"

--- a/martian-filetypes/src/macros.rs
+++ b/martian-filetypes/src/macros.rs
@@ -30,9 +30,7 @@ macro_rules! martian_filetype_inner {
             }
 
             fn new(file_path: impl AsRef<std::path::Path>, file_name: impl AsRef<std::path::Path>) -> Self {
-                let mut path = std::path::PathBuf::from(file_path.as_ref());
-                path.push(file_name);
-                let path = ::martian::utils::set_extension(path, Self::extension());
+				let path = ::martian::utils::make_path(file_path.as_ref(), file_name.as_ref(), Self::extension());
                 $name {
 		            inner: ::std::marker::PhantomData,
 		            path,

--- a/martian-filetypes/src/macros.rs
+++ b/martian-filetypes/src/macros.rs
@@ -2,63 +2,63 @@
 #[macro_export]
 macro_rules! martian_filetype_inner {
     ($(#[$attr:meta])* pub struct $name:ident, $extension:expr) => (
-    	$(#[$attr])*
-    	#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-		// The following attribute ensures that the struct will serialize into a
-		// String like a PathBuf would.
-		#[serde(transparent)]
-		pub struct $name<F>
-		where
-		    F: ::martian::MartianFileType,
-		{
-		    // Skip [de]serializing the inner
-		    #[serde(skip)]
-		    inner: ::std::marker::PhantomData<F>,
-		    path: ::std::path::PathBuf,
-		}
+        $(#[$attr])*
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+        // The following attribute ensures that the struct will serialize into a
+        // String like a PathBuf would.
+        #[serde(transparent)]
+        pub struct $name<F>
+        where
+            F: ::martian::MartianFileType,
+        {
+            // Skip [de]serializing the inner
+            #[serde(skip)]
+            inner: ::std::marker::PhantomData<F>,
+            path: ::std::path::PathBuf,
+        }
 
         impl<F> ::martian::MartianFileType for $name<F>
-		where
-		    F: ::martian::MartianFileType,
-		{
+        where
+            F: ::martian::MartianFileType,
+        {
             fn extension() -> String {
                 if F::extension().ends_with($extension) || $extension == "" {
-                	F::extension()
+                    F::extension()
                 } else {
-                	format!("{}.{}", F::extension(), $extension)
+                    format!("{}.{}", F::extension(), $extension)
                 }
             }
 
             fn new(file_path: impl AsRef<std::path::Path>, file_name: impl AsRef<std::path::Path>) -> Self {
-				let path = ::martian::utils::make_path(file_path.as_ref(), file_name.as_ref(), Self::extension());
+                let path = ::martian::utils::make_path(file_path.as_ref(), file_name.as_ref(), Self::extension());
                 $name {
-		            inner: ::std::marker::PhantomData,
-		            path,
-		        }
+                    inner: ::std::marker::PhantomData,
+                    path,
+                }
             }
         }
         impl<F> AsRef<std::path::Path> for $name<F>
         where
-        	F: ::martian::MartianFileType
+            F: ::martian::MartianFileType
         {
             fn as_ref(&self) -> &std::path::Path {
                 self.path.as_ref()
             }
         }
 
-    	impl<F, P> From<P> for $name<F>
-		where
-		    ::std::path::PathBuf: From<P>,
-		    F: ::martian::MartianFileType,
-		{
-		    fn from(source: P) -> Self {
-		        let path_buf = ::std::path::PathBuf::from(source);
-		        let file_name = path_buf.file_name().unwrap();
-		        match path_buf.parent() {
-		            Some(path) => ::martian::MartianFileType::new(path, file_name),
-		            None => ::martian::MartianFileType::new("", file_name),
-		        }
-		    }
-		}
+        impl<F, P> From<P> for $name<F>
+        where
+            ::std::path::PathBuf: From<P>,
+            F: ::martian::MartianFileType,
+        {
+            fn from(source: P) -> Self {
+                let path_buf = ::std::path::PathBuf::from(source);
+                let file_name = path_buf.file_name().unwrap();
+                match path_buf.parent() {
+                    Some(path) => ::martian::MartianFileType::new(path, file_name),
+                    None => ::martian::MartianFileType::new("", file_name),
+                }
+            }
+        }
     )
 }

--- a/martian-lab/examples/sum_sq/src/sum_squares.rs
+++ b/martian-lab/examples/sum_sq/src/sum_squares.rs
@@ -85,6 +85,8 @@ impl MartianStage for SumSquares {
         chunk_args: Self::ChunkInputs,
         _rover: MartianRover,
     ) -> Result<Self::ChunkOutputs, Error> {
+        // This is a special sentinel value, so the comparison should be exact.
+        #[allow(clippy::float_cmp)]
         if chunk_args.value == 123456789.0 {
             // let the other chunks finish
             let dur = std::time::Duration::new(3, 0);
@@ -112,6 +114,8 @@ impl MartianStage for SumSquares {
 
 #[cfg(test)]
 mod tests {
+    // Float comparisons are bad in general, but we expect this to be exact.
+    #![allow(clippy::float_cmp)]
     use super::*;
     #[test]
     fn run_stage() {

--- a/martian-lab/examples/sum_sq_main/src/sum_squares.rs
+++ b/martian-lab/examples/sum_sq_main/src/sum_squares.rs
@@ -58,6 +58,8 @@ impl MartianMain for SumSquares {
 
 #[cfg(test)]
 mod tests {
+    // Float comparisons are bad in general, but we expect this to be exact.
+    #![allow(clippy::float_cmp)]
     use super::*;
     #[test]
     fn run_stage() {

--- a/martian-lab/tests/error_test/expected/SUM_SQUARES/SUM_SQUARES/fork0/chnk3/_stackvars
+++ b/martian-lab/tests/error_test/expected/SUM_SQUARES/SUM_SQUARES/fork0/chnk3/_stackvars
@@ -1,33 +1,41 @@
    0: <sum_sq::sum_squares::SumSquares as martian::stage::MartianStage>::main
-             at /mnt/home/sreenath.krishnan/codes/martian-rust/martian-lab/examples/sum_sq/src/sum_squares.rs:94
+             at /github.com/martian-lang/martian-rust/martian-lab/examples/sum_sq/src/sum_squares.rs:94:24
    1: <T as martian::stage::RawMartianStage>::main
-             at /mnt/home/sreenath.krishnan/codes/martian-rust/martian/src/stage.rs:644
+             at /github.com/martian-lang/martian-rust/martian/src/stage.rs:642:20
    2: martian::martian_entry_point
-             at /mnt/home/sreenath.krishnan/codes/martian-rust/martian/src/lib.rs:225
+             at /github.com/martian-lang/martian-rust/martian/src/lib.rs:231:9
    3: martian::MartianAdapter<S>::run_get_error
-             at /mnt/home/sreenath.krishnan/codes/martian-rust/martian/src/lib.rs:131
+             at /github.com/martian-lang/martian-rust/martian/src/lib.rs:133:9
    4: martian::MartianAdapter<S>::run
-             at /mnt/home/sreenath.krishnan/codes/martian-rust/martian/src/lib.rs:124
+             at /github.com/martian-lang/martian-rust/martian/src/lib.rs:126:9
    5: sum_sq::main
-             at /mnt/home/sreenath.krishnan/codes/martian-rust/martian-lab/examples/sum_sq/src/main.rs:48
+             at /github.com/martian-lang/martian-rust/martian-lab/examples/sum_sq/src/main.rs:48:23
    6: core::ops::function::FnOnce::call_once
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/core/src/ops/function.rs:227
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227:5
    7: std::sys_common::backtrace::__rust_begin_short_backtrace
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/sys_common/backtrace.rs:137
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/sys_common/backtrace.rs:125:18
    8: std::rt::lang_start::{{closure}}
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:66
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/rt.rs:63:18
    9: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/core/src/ops/function.rs:259
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:259:13
       std::panicking::try::do_call
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:373
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:401:40
       std::panicking::try
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:337
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:365:19
       std::panic::catch_unwind
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:379
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:434:14
       std::rt::lang_start_internal::{{closure}}
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:51
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/rt.rs:45:48
+      std::panicking::try::do_call
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:401:40
+      std::panicking::try
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:365:19
+      std::panic::catch_unwind
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:434:14
+      std::rt::lang_start_internal
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/rt.rs:45:20
   10: std::rt::lang_start
-             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:65
+             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/rt.rs:62:5
   11: main
   12: __libc_start_main
-  13: <unknown>
+  13: _start

--- a/martian-lab/tests/error_test/expected/SUM_SQUARES/SUM_SQUARES/fork0/chnk3/_stackvars
+++ b/martian-lab/tests/error_test/expected/SUM_SQUARES/SUM_SQUARES/fork0/chnk3/_stackvars
@@ -24,7 +24,7 @@
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panicking.rs:337
       std::panic::catch_unwind
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/panic.rs:379
-      std::rt::lang_start_internal
+      std::rt::lang_start_internal::{{closure}}
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:51
   10: std::rt::lang_start
              at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39/library/std/src/rt.rs:65

--- a/martian/Cargo.toml
+++ b/martian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 include = ["src/*.rs", "README.md"]

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -163,9 +163,10 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
     };
 
     // Get the stage implementation
-    let _stage = stage_map
-        .get(&md.stage_name)
-        .ok_or_else(|| format_err!("Couldn't find requested Martian stage: {}", md.stage_name));
+    let _stage = stage_map.get(&md.stage_name).ok_or_else(
+        #[cold]
+        || format_err!("Couldn't find requested Martian stage: {}", md.stage_name),
+    );
 
     // special handler for non-existent stage
     let stage = match _stage {
@@ -182,44 +183,47 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
 
     // Setup panic hook. If a stage panics, we'll shutdown cleanly to martian
     let p = panic::take_hook();
-    panic::set_hook(Box::new(move |info| {
-        let backtrace = Backtrace::new();
+    panic::set_hook(Box::new(
+        #[cold]
+        move |info| {
+            let backtrace = Backtrace::new();
 
-        let msg = match info.payload().downcast_ref::<&'static str>() {
-            Some(s) => *s,
-            None => match info.payload().downcast_ref::<String>() {
-                Some(s) => &**s,
-                None => "Box<Any>",
-            },
-        };
+            let msg = match info.payload().downcast_ref::<&'static str>() {
+                Some(s) => *s,
+                None => match info.payload().downcast_ref::<String>() {
+                    Some(s) => &**s,
+                    None => "Box<Any>",
+                },
+            };
 
-        let msg = match info.location() {
-            Some(location) => format!(
-                "stage failed unexpectedly: '{}' {}:{}:\n{:?}",
-                msg,
-                location.file(),
-                location.line(),
-                backtrace
-            ),
-            None => format!("stage failed unexpectedly: '{}':\n{:?}", msg, backtrace),
-        };
+            let msg = match info.location() {
+                Some(location) => format!(
+                    "stage failed unexpectedly: '{}' {}:{}:\n{:?}",
+                    msg,
+                    location.file(),
+                    location.line(),
+                    backtrace
+                ),
+                None => format!("stage failed unexpectedly: '{}':\n{:?}", msg, backtrace),
+            };
 
-        // write to _log
-        error!("{}", msg);
+            // write to _log
+            error!("{}", msg);
 
-        // write stack trace to to _stackvars.
-        // this will just give up if any errors are encountere
-        let bt_string = format!("{:?}", backtrace);
-        let _ = File::create(&stackvars_path).map(|mut f| {
-            let _ = f.write_all(bt_string.as_bytes());
-        });
+            // write stack trace to to _stackvars.
+            // this will just give up if any errors are encountere
+            let bt_string = format!("{:?}", backtrace);
+            let _ = File::create(&stackvars_path).map(|mut f| {
+                let _ = f.write_all(bt_string.as_bytes());
+            });
 
-        // write to _errors
-        let _ = write_errors(&msg, false);
+            // write to _errors
+            let _ = write_errors(&msg, false);
 
-        // call default panic handler (not sure if this is a good idea or not)
-        p(info);
-    }));
+            // call default panic handler (not sure if this is a good idea or not)
+            p(info);
+        },
+    ));
 
     let result = if md.stage_type == "split" {
         stage.split(&mut md)
@@ -237,14 +241,19 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
 
         // write message and stack trace, exit code = 1;
         Err(e) => {
-            let bt = e.backtrace();
-            let _ = md.stackvars(&bt.to_string());
-            let _ = write_errors(&format!("{}", e), is_error_assert(&e));
+            report_error(&mut md, &e, is_error_assert(&e));
             (1, Some(e))
         }
     };
 
     res
+}
+
+#[cold]
+fn report_error(md: &mut Metadata, e: &Error, is_assert: bool) {
+    let bt = e.backtrace();
+    let _ = md.stackvars(&bt.to_string());
+    let _ = write_errors(&format!("{}", e), is_assert);
 }
 
 fn get_generator_name() -> String {

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -45,6 +45,7 @@ pub fn initialize(args: Vec<String>) -> Result<Metadata, Error> {
     Ok(md)
 }
 
+#[cold]
 fn write_errors(msg: &str, is_assert: bool) -> Result<(), Error> {
     let mut err_file: File = unsafe { File::from_raw_fd(4) };
 

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -235,7 +235,7 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
         panic!("Unrecognized stage type");
     };
 
-    let res = match result {
+    match result {
         // exit code = 0
         Ok(()) => (0, None),
 
@@ -244,9 +244,7 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
             report_error(&mut md, &e, is_error_assert(&e));
             (1, Some(e))
         }
-    };
-
-    res
+    }
 }
 
 #[cold]

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -180,12 +180,16 @@ impl Metadata {
     }
 
     fn _decode<T: Sized + DeserializeOwned>(file: PathBuf) -> Result<T> {
-        let buf = std::fs::read_to_string(&file).map_err(|e| {
-            let context = format!("Failed to read file {:?} due to {}:", file, e);
-            Error::new(e).context(context)
-        })?;
+        let buf = Self::_read_buf_err(&file)?;
         serde_json::from_str(&buf).map_err(|e| {
             let context = Self::_format_buf_err(buf, &e, file, type_name::<T>());
+            Error::new(e).context(context)
+        })
+    }
+
+    fn _read_buf_err(file: &PathBuf) -> Result<String> {
+        std::fs::read_to_string(&file).map_err(|e| {
+            let context = format!("Failed to read file {:?} due to {}:", file, e);
             Error::new(e).context(context)
         })
     }

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -181,19 +181,26 @@ impl Metadata {
 
     fn _decode<T: Sized + DeserializeOwned>(file: PathBuf) -> Result<T> {
         let buf = Self::_read_buf_err(&file)?;
-        serde_json::from_str(&buf).map_err(|e| {
-            let context = Self::_format_buf_err(buf, &e, file, type_name::<T>());
-            Error::new(e).context(context)
-        })
+        serde_json::from_str(&buf).map_err(
+            #[cold]
+            |e| {
+                let context = Self::_format_buf_err(buf, &e, file, type_name::<T>());
+                Error::new(e).context(context)
+            },
+        )
     }
 
     fn _read_buf_err(file: &PathBuf) -> Result<String> {
-        std::fs::read_to_string(&file).map_err(|e| {
-            let context = format!("Failed to read file {:?} due to {}:", file, e);
-            Error::new(e).context(context)
-        })
+        std::fs::read_to_string(&file).map_err(
+            #[cold]
+            |e| {
+                let context = format!("Failed to read file {:?} due to {}:", file, e);
+                Error::new(e).context(context)
+            },
+        )
     }
 
+    #[cold]
     fn _format_buf_err(
         buf: String,
         e: &serde_json::Error,
@@ -253,10 +260,12 @@ impl Metadata {
         self._append("alarm", &format!("{} {}", make_timestamp_now(), message))
     }
 
+    #[cold]
     pub fn assert(&mut self, message: &str) -> Result<()> {
         write_errors(message, true)
     }
 
+    #[cold]
     pub fn stackvars(&mut self, message: &str) -> Result<()> {
         self.write_raw("stackvars", message)
     }

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use std::fs::{rename, File, OpenOptions};
 use std::io::Write;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub type JsonDict = Map<String, Value>;
 pub type Json = Value;
@@ -190,7 +190,7 @@ impl Metadata {
         )
     }
 
-    fn _read_buf_err(file: &PathBuf) -> Result<String> {
+    fn _read_buf_err(file: &Path) -> Result<String> {
         std::fs::read_to_string(&file).map_err(
             #[cold]
             |e| {


### PR DESCRIPTION
Specifically reduce the amount of code duplicated by many
macro-generated `MartianFileType::new` definitions, plus a little more
effort on reducing the overhead on `Metadata::_decode`.

Also, mark some of the error pathways as [`#[cold]`](https://doc.rust-lang.org/reference/attributes/codegen.html#the-cold-attribute), as a hint
to the compiler.