### PR TITLE
Various fixes and cleanups (including breaking changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,18 +154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,11 +506,10 @@ dependencies = [
 
 [[package]]
 name = "martian"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "backtrace",
- "chrono",
  "fern",
  "heck",
  "indoc",
@@ -535,11 +522,12 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "time",
 ]
 
 [[package]]
 name = "martian-derive"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "martian",
  "pretty_assertions",
@@ -603,16 +591,6 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -1067,6 +1045,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "itoa",
+ "libc",
 ]
 
 [[package]]

--- a/cargo-martian/src/template.rs
+++ b/cargo-martian/src/template.rs
@@ -31,12 +31,12 @@ use martian_derive::*;
 // If you want to declare a new filetype use the `martian_filetype!` macro:
 // martian_filetype!(Lz4File, "lz4");
 
-#[derive(Debug, Clone, Serialize, Deserialize, MartianStruct)]
+#[derive(Debug, Clone, Deserialize, MartianStruct)]
 pub struct {stage}StageInputs {open}
     // TODO: Add fields here. This cannot be an empty struct or a tuple struct
 {close}
 
-#[derive(Debug, Clone, Serialize, Deserialize, MartianStruct)]
+#[derive(Debug, Clone, Serialize, MartianStruct)]
 pub struct {stage}StageOutputs {open}
     // TODO: Add fields here. If there are no stage outputs, use `MartianVoid`
 {close}
@@ -122,12 +122,12 @@ use martian_derive::*;
 // If you want to declare a new filetype use the `martian_filetype!` macro:
 // martian_filetype!(Lz4File, "lz4");
 
-#[derive(Debug, Clone, Serialize, Deserialize, MartianStruct)]
+#[derive(Debug, Clone, Deserialize, MartianStruct)]
 pub struct {stage}StageInputs {open}
     // TODO: Add fields here. This cannot be an empty struct or a tuple struct
 {close}
 
-#[derive(Debug, Clone, Serialize, Deserialize, MartianStruct)]
+#[derive(Debug, Clone, Serialize, MartianStruct)]
 pub struct {stage}StageOutputs {open}
     // TODO: Add fields here. If there are no stage outputs, use `MartianVoid`
     // as the associated type

--- a/deny.toml
+++ b/deny.toml
@@ -27,7 +27,6 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    "RUSTSEC-2020-0159",  # TODO: upgrade when possible, or find an alternative.
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/martian-derive/Cargo.toml
+++ b/martian-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-derive"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 include = ["src/lib.rs", "README.md"]

--- a/martian-derive/README.md
+++ b/martian-derive/README.md
@@ -71,8 +71,8 @@ impl ::martian::MroMaker for SumSquares {
     fn chunk_in_and_out() -> Option<::martian::InAndOut> {
         None
     }
-    fn stage_name() -> String {
-        String::from("SUM_SQUARES")
+    fn stage_name() -> &'static str {
+        "SUM_SQUARES"
     }
     fn using_attributes() -> ::martian::MroUsing {
         ::martian::MroUsing {
@@ -114,8 +114,8 @@ impl ::martian::AsMartianPrimaryType for Chemistry {
 
 ```rust
 impl ::martian::MartianFileType for TxtFile {
-    fn extension() -> &'static str {
-        "txt"
+    fn extension() -> String {
+        "txt".into()
     }
     fn new(
         file_path: impl ::std::convert::AsRef<::std::path::Path>,

--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -815,12 +815,7 @@ pub fn martian_filetype(item: proc_macro::TokenStream) -> proc_macro::TokenStrea
             ::std::path::PathBuf: ::std::convert::From<T>,
         {
             fn from(source: T) -> Self {
-                let path_buf = ::std::path::PathBuf::from(source);
-                let file_name = path_buf.file_name().unwrap();
-                match path_buf.parent() {
-                    Some(path) => ::martian::MartianFileType::new(path, file_name),
-                    None => ::martian::MartianFileType::new("", file_name),
-                }
+                ::martian::MartianFileType::from_path(::std::path::PathBuf::from(source).as_ref())
             }
         }
     ]

--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -172,8 +172,8 @@ pub fn make_mro(
     let stage_name =
         utils::to_shouty_snake_case(&parsed_attr.stage_name.unwrap_or(stage_struct_name));
     let stage_name_fn = quote![
-        fn stage_name() -> String {
-            String::from(#stage_name)
+        fn stage_name() -> &'static str {
+            #stage_name
         }
     ];
 
@@ -344,9 +344,11 @@ macro_rules! attr_parse {
                 }
                 $(let mut $property = None;)*
                 for using_spec in s.split(',') {
-                    let parts: Vec<_> = using_spec.trim().split("=").map(str::trim).collect();
+                    let parts: Vec<_> = using_spec.trim().splitn(3, '=').map(str::trim).collect();
                     if parts.len() != 2 {
-                        return Err(format!("Expecting a comma separated `key=value` like tokens here. The allowed keys are: [{}]", stringify!($($property),*)));
+                        return Err(format!(
+                            "Expecting a comma separated `key=value` like tokens here. The allowed keys are: [{}]",
+                            stringify!($($property),*)));
                     }
                     match parts[0] {
                         $(stringify!($property) => {
@@ -356,10 +358,14 @@ macro_rules! attr_parse {
                             }
                             $property = match parts[1].parse::<$type>() {
                                 Ok(parsed) => Some(parsed),
-                                Err(_) => return Err(format!("Unable to parse {0} as {1} from `{0}={2}`", parts[0], stringify!($type), parts[1]))
+                                Err(_) => return Err(format!(
+                                    "Unable to parse {0} as {1} from `{0}={2}`",
+                                    parts[0], stringify!($type), parts[1]))
                             };
                         },)*
-                        _ => return Err(format!("Expecting a comma separated `key=value` like tokens here. The allowed keys are: [{}]. Found an invalid key {}", stringify!($($property),*), parts[0]))
+                        _ => return Err(format!(
+                            "Expecting a comma separated `key=value` like tokens here. The allowed keys are: [{}]. Found an invalid key {}",
+                            stringify!($($property),*), parts[0]))
                     }
                 }
                 Ok(MakeMroAttr {

--- a/martian-filetypes/benches/benchmarks.rs
+++ b/martian-filetypes/benches/benchmarks.rs
@@ -70,29 +70,26 @@ where
     let file_lazy = F::new(dir.path(), "benchmark_lazy");
     let file_lz4 = Lz4::<F>::new(dir.path(), "benchmark_lz4");
     let file_lz4_lazy = Lz4::<F>::new(dir.path(), "benchmark_lz4_lazy");
-    let data_copy1 = data.clone();
-    let data_copy2 = data.clone();
-    let data_copy3 = data.clone();
     let elements = data.len() as u32;
 
     let mut group = c.benchmark_group(key);
     group.throughput(Throughput::Elements(elements.into()));
     group.sample_size(10);
-    group.bench_function("full-write", move |b| b.iter(|| file_full.write(&data)));
-    group.bench_function("lazy-write", move |b| {
+    group.bench_function("full-write", |b| b.iter(|| file_full.write(&data)));
+    group.bench_function("lazy-write", |b| {
         b.iter(|| {
             let mut writer = file_lazy.lazy_writer().unwrap();
-            for d in &data_copy1 {
+            for d in &data {
                 writer.write_item(d).unwrap();
             }
             writer.finish()
         })
     });
-    group.bench_function("lz4-write", move |b| b.iter(|| file_lz4.write(&data_copy2)));
-    group.bench_function("lz4-lazy-write", move |b| {
+    group.bench_function("lz4-write", |b| b.iter(|| file_lz4.write(&data)));
+    group.bench_function("lz4-lazy-write", |b| {
         b.iter(|| {
             let mut writer = file_lz4_lazy.lazy_writer().unwrap();
-            for d in &data_copy3 {
+            for d in &data {
                 writer.write_item(d).unwrap();
             }
             writer.finish()

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -320,6 +320,14 @@ where
     }
 }
 
+pub(crate) fn maybe_add_format(extension: String, format: &str) -> String {
+    if extension.ends_with(format) || format.is_empty() {
+        extension
+    } else {
+        format!("{}.{}", extension, format)
+    }
+}
+
 #[cfg(test)]
 pub fn round_trip_check<F, T>(input: &T) -> Result<bool, Error>
 where

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -145,6 +145,7 @@ use martian::{Error, MartianFileType};
 use std::fmt;
 use std::fs::File;
 use std::io;
+use std::iter::FromIterator;
 use std::path::PathBuf;
 
 pub mod bin_file;
@@ -267,13 +268,12 @@ pub trait LazyFileTypeIO<T>: MartianFileType + Sized + FileStorage<Vec<T>> {
     fn lazy_reader(&self) -> Result<Self::LazyReader, Error>;
 
     /// Consume the reader and read all the items
-    fn read_all(&self) -> Result<Vec<T>, Error> {
+    fn read_all<V>(&self) -> Result<V, Error>
+    where
+        V: FromIterator<T>,
+    {
         let reader = self.lazy_reader()?;
-        let mut items = Vec::new();
-        for item in reader {
-            items.push(item?);
-        }
-        Ok(items)
+        reader.into_iter().collect()
     }
     /// Get a lazy writer for this `MartianFileType`
     fn lazy_writer(&self) -> Result<Self::LazyWriter, Error>;
@@ -390,7 +390,7 @@ where
             lazy_writer.write_item(item)?;
         }
         lazy_writer.finish()?;
-        let decoded: Vec<T> = file.read()?;
+        let decoded = file.read()?;
         input == &decoded
     } else {
         true
@@ -405,7 +405,7 @@ where
             lazy_writer.write_item(item)?;
         }
         lazy_writer.finish()?;
-        let decoded: Vec<T> = file.read()?;
+        let decoded = file.read()?;
         input == &decoded
     } else {
         true

--- a/martian-filetypes/src/lz4_file.rs
+++ b/martian-filetypes/src/lz4_file.rs
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_lz4_extension() {
-        assert_eq!(Lz4::<JsonFile>::extension(), String::from("json.lz4"));
+        assert_eq!(Lz4::<JsonFile>::extension(), "json.lz4");
     }
 
     #[test]

--- a/martian-filetypes/src/macros.rs
+++ b/martian-filetypes/src/macros.rs
@@ -22,11 +22,7 @@ macro_rules! martian_filetype_inner {
             F: ::martian::MartianFileType,
         {
             fn extension() -> String {
-                if F::extension().ends_with($extension) || $extension == "" {
-                    F::extension()
-                } else {
-                    format!("{}.{}", F::extension(), $extension)
-                }
+                crate::maybe_add_format(F::extension(), $extension)
             }
 
             fn new(file_path: impl AsRef<std::path::Path>, file_name: impl AsRef<std::path::Path>) -> Self {
@@ -53,11 +49,7 @@ macro_rules! martian_filetype_inner {
         {
             fn from(source: P) -> Self {
                 let path_buf = ::std::path::PathBuf::from(source);
-                let file_name = path_buf.file_name().unwrap();
-                match path_buf.parent() {
-                    Some(path) => ::martian::MartianFileType::new(path, file_name),
-                    None => ::martian::MartianFileType::new("", file_name),
-                }
+                Self::from_path(path_buf.as_path())
             }
         }
     )

--- a/martian/Cargo.toml
+++ b/martian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 include = ["src/*.rs", "README.md"]
@@ -10,7 +10,7 @@ license = "MIT"
 libc = "*"
 log = "0.4"
 fern = ">=0.5, <=0.6"
-chrono = { version = "*", default-features = false, features = ["std", "clock"] }
+time = { version = ">=0.3", features = ["formatting", "local-offset"] }
 serde = { version = "1.0", features = ['derive'] }
 serde_json = "1.0"
 backtrace = "*"

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -1,5 +1,6 @@
+use crate::DATE_FORMAT;
 use crate::{write_errors, Error};
-use chrono::{DateTime, Local};
+use time::{OffsetDateTime, UtcOffset};
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -12,6 +13,7 @@ use std::fs::{rename, File, OpenOptions};
 use std::io::Write;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 pub type JsonDict = Map<String, Value>;
 pub type Json = Value;
@@ -100,12 +102,18 @@ impl RustAdapterInfo {
     }
 }
 
-pub fn make_timestamp(datetime: DateTime<Local>) -> String {
-    datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+pub fn make_timestamp(datetime: impl Into<OffsetDateTime>) -> String {
+    _make_timestamp(datetime.into())
+}
+
+fn _make_timestamp(datetime: OffsetDateTime) -> String {
+    // Convert to local time (if necessary)
+    let datetime = datetime.to_offset(UtcOffset::local_offset_at(datetime).unwrap());
+    datetime.format(DATE_FORMAT).unwrap()
 }
 
 pub fn make_timestamp_now() -> String {
-    make_timestamp(Local::now())
+    make_timestamp(SystemTime::now())
 }
 
 impl Metadata {

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -126,9 +126,7 @@ impl Metadata {
 
     /// Path within chunk
     pub fn make_path(&self, name: &str) -> PathBuf {
-        let mut pb = PathBuf::from(self.metadata_path.clone());
-        pb.push(METADATA_PREFIX.to_string() + name);
-        pb
+        Path::new(name).join(METADATA_PREFIX.to_string() + name)
     }
 
     /// Write to a file inside the chunk
@@ -338,7 +336,7 @@ mod tests {
             val: i32,
         }
 
-        let e: Result<Foo> = Metadata::_decode(PathBuf::from("tests/invalid_args.json"));
+        let e: Result<Foo> = Metadata::_decode("tests/invalid_args.json".into());
         insta::assert_display_snapshot!(e.unwrap_err());
     }
 }

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -151,7 +151,7 @@ impl Metadata {
         let mut f = File::create(self.make_path(name))?;
         f.write_all(text.as_bytes())?;
         // Ensure the file is closed before we write the journal, to reduce
-        // the changes that `mrp` sees the journal entry before the file content
+        // the chances that `mrp` sees the journal entry before the file content
         // has be sync'ed.  This can be an issue on nfs systems.
         drop(f);
         self.update_journal(name)?;
@@ -254,7 +254,7 @@ impl Metadata {
         file.write_all(message.as_bytes())?;
         file.write_all(b"\n")?;
         // Ensure the file is closed before we write the journal, to reduce
-        // the changes that `mrp` sees the journal entry before the file content
+        // the chances that `mrp` sees the journal entry before the file content
         // has be sync'ed.  This can be an issue on nfs systems.
         drop(file);
         self.update_journal(name)?;
@@ -312,7 +312,7 @@ impl Metadata {
         }
     }
 
-    /// Equivalentt to write_json_obj() followed by complete()
+    /// Equivalent to write_json_obj() followed by complete()
     pub(crate) fn complete_with(&mut self, out_filename: &str, out_data: &JsonDict) -> Result<()> {
         self.write_json_obj(out_filename, out_data)?;
         self.complete();

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -760,7 +760,7 @@ pub trait MroMaker {
             stage_mro.to_string()
         )
     }
-    fn stage_name() -> String;
+    fn stage_name() -> &'static str;
     fn stage_in_and_out() -> InAndOut;
     fn chunk_in_and_out() -> Option<InAndOut>;
     fn using_attributes() -> MroUsing;
@@ -769,7 +769,7 @@ pub trait MroMaker {
 /// All the data needed to create a stage definition mro.
 #[derive(Debug)]
 pub struct StageMro {
-    stage_name: String,     // e.g CORRECT_BARCODES in `stage CORRECT_BARCODES(..)`
+    stage_name: &'static str, // e.g CORRECT_BARCODES in `stage CORRECT_BARCODES(..)`
     adapter_name: String, // Martian adapter e.g `cr_slfe` in `src comp "cr_slfe martian correct_barcodes"
     stage_key: String, // Key used in the hashmap containing all stages e.g `correct_barcodes` in `src comp "cr_slfe martian correct_barcodes"
     stage_in_out: InAndOut, // Inputs and outputs of the stage
@@ -1063,7 +1063,7 @@ mod tests {
         );
 
         let stage_mro = StageMro {
-            stage_name: "SUM_SQUARES".into(),
+            stage_name: "SUM_SQUARES",
             adapter_name: "my_adapter".into(),
             stage_key: "sum_squares".into(),
             stage_in_out: InAndOut {
@@ -1094,7 +1094,7 @@ mod tests {
         );
 
         let stage_mro = StageMro {
-            stage_name: "SUM_SQUARES".into(),
+            stage_name: "SUM_SQUARES",
             adapter_name: "my_adapter".into(),
             stage_key: "sum_squares".into(),
             stage_in_out: InAndOut {
@@ -1121,7 +1121,7 @@ mod tests {
         );
 
         let stage_mro = StageMro {
-            stage_name: "SUM_SQUARES".into(),
+            stage_name: "SUM_SQUARES",
             adapter_name: "my_adapter".into(),
             stage_key: "sum_squares".into(),
             stage_in_out: InAndOut {
@@ -1151,7 +1151,7 @@ mod tests {
         );
 
         let stage_mro = StageMro {
-            stage_name: "SUM_SQUARES".into(),
+            stage_name: "SUM_SQUARES",
             adapter_name: "my_adapter".into(),
             stage_key: "sum_squares".into(),
             stage_in_out: InAndOut {
@@ -1187,7 +1187,7 @@ mod tests {
         );
 
         let stage_mro = StageMro {
-            stage_name: "SUM_SQUARES".into(),
+            stage_name: "SUM_SQUARES",
             adapter_name: "my_adapter".into(),
             stage_key: "sum_squares".into(),
             stage_in_out: InAndOut {
@@ -1209,7 +1209,7 @@ mod tests {
     #[should_panic]
     fn test_stage_mro_display_duplicate_inputs() {
         let stage_mro = StageMro {
-            stage_name: "SUM_SQUARES".into(),
+            stage_name: "SUM_SQUARES",
             adapter_name: "my_adapter".into(),
             stage_key: "sum_squares".into(),
             stage_in_out: InAndOut {
@@ -1233,7 +1233,7 @@ mod tests {
     #[should_panic]
     fn test_stage_mro_display_duplicate_outputs() {
         let stage_mro = StageMro {
-            stage_name: "SUM_SQUARES".into(),
+            stage_name: "SUM_SQUARES",
             adapter_name: "my_adapter".into(),
             stage_key: "sum_squares".into(),
             stage_in_out: InAndOut {
@@ -1256,7 +1256,7 @@ mod tests {
     #[test]
     fn test_stage_mro_display_duplicate_outputs_same_type() {
         let stage_mro = StageMro {
-            stage_name: "SUM_SQUARES".into(),
+            stage_name: "SUM_SQUARES",
             adapter_name: "my_adapter".into(),
             stage_key: "sum_squares".into(),
             stage_in_out: InAndOut {
@@ -1509,7 +1509,7 @@ mod tests {
         };
 
         let stage_mro = StageMro {
-            stage_name: "SETUP_CHUNKS".into(),
+            stage_name: "SETUP_CHUNKS",
             adapter_name: "my_adapter".into(),
             stage_key: "setup_chunks".into(),
             stage_in_out: InAndOut {

--- a/martian/src/stage.rs
+++ b/martian/src/stage.rs
@@ -461,9 +461,9 @@ fn split_prelude(
     let default_resource = Resource::new().mem_gb(1).vmem_gb(2).threads(1);
     let split_path = prep_path(run_directory, subdir)?;
     let rover = MartianRover::new(split_path.as_path(), default_resource);
-    println!("{}", ["-"; 80].join(""));
+    println!("{}", ["-"; 80].concat());
     println!("{}", stage_name);
-    println!("{}", ["-"; 80].join(""));
+    println!("{}", ["-"; 80].concat());
     Ok(rover)
 }
 

--- a/martian/src/utils.rs
+++ b/martian/src/utils.rs
@@ -130,9 +130,7 @@ fn _set_extension(mut result: PathBuf, extension: String) -> PathBuf {
 /// generating large amounts of duplicate code, and should generally not be
 /// used directly.
 pub fn make_path(file_path: &Path, file_name: &Path, extension: String) -> PathBuf {
-    let mut path = PathBuf::from(file_path);
-    path.push(file_name);
-    _set_extension(path, extension)
+    _set_extension(file_path.join(file_name), extension)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Remove some unnecessary trait bounds.  These force users to implement traits which we don't actually need them to implement, which can result in significant code bloat (particularly for `Serialize` and `Deserialize`).

Switch some `String`s to `str`s to avoid pointless copying.

Do a bunch more things to reduce duplicating code during monomorphization.

Fix a bug where the journal was being written before before the file was closed.

Switch from `chrono` to `time`.