### PR TITLE
Add profile mode pyspy

### DIFF
--- a/cargo-martian/src/main.rs
+++ b/cargo-martian/src/main.rs
@@ -28,6 +28,7 @@ Options:
 struct Args {
     flag_pkg: Option<String>,
     flag_version: bool,
+    #[allow(dead_code)]
     cmd_martian: bool,
     cmd_stage: bool,
     cmd_adapter: bool,

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -70,6 +70,7 @@ pub enum ProfileMode {
     Line,
     Mem,
     Perf,
+    Pyspy,
 }
 
 impl Default for ProfileMode {


### PR DESCRIPTION
I added it to martian here:
https://github.com/10XDev/martian-public/pull/394
And this change is needed so we can turn on pyspy for martian rust stages.
