### PR TITLE
Various cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,9 +987,9 @@ checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
 name = "strfmt"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b278b244ef7aa5852b277f52dd0c6cac3a109919e1f6d699adde63251227a30f"
+checksum = "26cdabcdab6da7e8c2ac1160e917ec83e78bbe3e10325e17d532718c67a4828f"
 
 [[package]]
 name = "strsim"

--- a/cargo-martian/Cargo.toml
+++ b/cargo-martian/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT"
 docopt = "1.0"
 serde = { version = "1.0", features = ['derive'] }
 serde_json = "1.0"
-strfmt = "0.1.6"
+strfmt = ">=0.1.6, <0.3"
 heck = "0.4"

--- a/cargo-martian/src/template.rs
+++ b/cargo-martian/src/template.rs
@@ -1,5 +1,4 @@
 use heck::{ToSnakeCase, ToUpperCamelCase};
-use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -174,10 +173,13 @@ pub fn new_stage(
     // Make sure the file does not exist already
     assert!(!path.exists(), "File {:?} already exists", path);
 
-    let mut vars = HashMap::new();
-    vars.insert("stage".into(), stage_name.to_upper_camel_case());
-    vars.insert("open".into(), "{".into());
-    vars.insert("close".into(), "}".into());
+    let vars = [
+        ("stage".to_string(), stage_name.to_upper_camel_case()),
+        ("open".to_string(), "{".to_string()),
+        ("close".to_string(), "}".to_string()),
+    ]
+    .into_iter()
+    .collect();
 
     let stage_template = if main_only {
         strfmt(STAGE_TEMPLATE_MAIN, &vars).unwrap()
@@ -278,10 +280,13 @@ pub fn new_adapter(adapter_name: impl AsRef<str>) {
     if exit_status.success() {
         {
             // Main file
-            let mut vars = HashMap::new();
-            vars.insert("adapter".into(), adapter_name.to_snake_case());
-            vars.insert("open".into(), "{".into());
-            vars.insert("close".into(), "}".into());
+            let vars = [
+                ("adapter".to_string(), adapter_name.to_snake_case()),
+                ("open".to_string(), "{".to_string()),
+                ("close".to_string(), "}".to_string()),
+            ]
+            .into_iter()
+            .collect();
 
             let mut path = PathBuf::from(&adapter_name);
             path.push("src");

--- a/martian-derive/tests/mro/test_main_only.mro
+++ b/martian-derive/tests/mro/test_main_only.mro
@@ -9,6 +9,7 @@ stage SUM_SQUARES(
     out float   sum_sq,
     src comp    "adapter martian sum_squares",
 ) using (
-    mem_gb  = 4,
-    threads = 2,
+    mem_gb   = 4,
+    threads  = 2,
+    volatile = strict,
 )

--- a/martian-derive/tests/mro/test_non_empty_split.mro
+++ b/martian-derive/tests/mro/test_non_empty_split.mro
@@ -12,5 +12,6 @@ stage CHUNK_READS(
 ) split (
     in  map<int>   read_chunk,
 ) using (
-    mem_gb = 2,
+    mem_gb   = 2,
+    volatile = strict,
 )

--- a/martian-derive/tests/mro/test_struct.mro
+++ b/martian-derive/tests/mro/test_struct.mro
@@ -36,4 +36,6 @@ stage SETUP_CHUNKS(
     out RnaChunk[]   chunks,
     out ChemistryDef chemistry_def,
     src comp         "my_adapter martian setup_chunks",
+) using (
+    volatile = strict,
 )

--- a/martian-derive/tests/mro/test_typed_map.mro
+++ b/martian-derive/tests/mro/test_typed_map.mro
@@ -30,4 +30,6 @@ stage STAGE_NAME(
     out ReadsStruct[]        multi_reads_struct,
     out ComplicatedStruct    complicated_struct2,
     src comp                 "my_adapter martian stage_name",
+) using (
+    volatile = strict,
 )

--- a/martian-derive/tests/mro/test_with_filetype.mro
+++ b/martian-derive/tests/mro/test_with_filetype.mro
@@ -15,6 +15,7 @@ stage SUM_SQUARES(
     out txt     log,
     src comp    "adapter martian sum_squares",
 ) using (
-    mem_gb  = 4,
-    threads = 2,
+    mem_gb   = 4,
+    threads  = 2,
+    volatile = strict,
 )


### PR DESCRIPTION
1. Permit stages to specify volatile = false.
2. Turn on volatile by default.
3. Don't build strings before we have to for MroDisplay.  Instead, just
   require implementation of Display, and read the width through
   standard channels.
4. In particular, don't allocate new strings just to take their length.
5. Implement `Into<&str>` for a few martian types.
6. Widen version range on strfmt.