### PR TITLE
MartianFileType: Implement Deref to &Path

### DIFF
--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -801,9 +801,12 @@ For example, martian_filetype! {TxtFile, \"txt\"}",
         pub struct #struct_ident(::std::path::PathBuf);
         #[automatically_derived]
         impl ::martian::MartianFileType for #struct_ident {
+            /// Returns the extension of this MartianFileType.
             fn extension() -> String {
                 #extension.into()
             }
+
+            /// Creates a MartianFileType from a directory path and a filename.
             fn new(
                 file_path: impl ::std::convert::AsRef<::std::path::Path>,
                 file_name: impl ::std::convert::AsRef<::std::path::Path>,
@@ -816,17 +819,30 @@ For example, martian_filetype! {TxtFile, \"txt\"}",
                 #struct_ident(path)
             }
         }
+
         #[automatically_derived]
         impl ::std::convert::AsRef<::std::path::Path> for #struct_ident {
+            /// Coerces this MartianFileType to a Path slice.
             fn as_ref(&self) -> &::std::path::Path {
                 &self.0
             }
         }
+
+        #[automatically_derived]
+        impl ::std::ops::Deref for #struct_ident {
+            type Target = ::std::path::Path;
+            /// Dereferences this MartianFileType to a Path slice.
+            fn deref(&self) -> &::std::path::Path {
+                &self.0
+            }
+        }
+
         #[automatically_derived]
         impl<T> ::std::convert::From<T> for #struct_ident
         where
             ::std::path::PathBuf: ::std::convert::From<T>,
         {
+            /// Convert a PathBuf (or something convertible to a PathBuf) into this MartianFileType.
             fn from(source: T) -> Self {
                 ::martian::MartianFileType::from_path(::std::path::PathBuf::from(source).as_ref())
             }

--- a/martian-filetypes/src/macros.rs
+++ b/martian-filetypes/src/macros.rs
@@ -33,12 +33,25 @@ macro_rules! martian_filetype_inner {
                 }
             }
         }
+
         impl<F> AsRef<std::path::Path> for $name<F>
         where
             F: ::martian::MartianFileType
         {
+            /// Coerces this MartianFileType to a Path slice.
             fn as_ref(&self) -> &std::path::Path {
-                self.path.as_ref()
+                &self.path
+            }
+        }
+
+        impl<F> std::ops::Deref for $name<F>
+        where
+            F: ::martian::MartianFileType
+        {
+            type Target = ::std::path::Path;
+            /// Dereferences this MartianFileType to a Path slice.
+            fn deref(&self) -> &::std::path::Path {
+                &self.path
             }
         }
 

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -90,7 +90,19 @@ where
     D: TableConfig + Debug,
 {
     fn as_ref(&self) -> &Path {
-        self.path.as_ref()
+        &self.path
+    }
+}
+
+impl<F, D> std::ops::Deref for DelimitedFormat<F, D>
+where
+    F: MartianFileType,
+    D: TableConfig + Debug,
+{
+    type Target = Path;
+    /// Dereferences this DelimitedFormat to a Path slice.
+    fn deref(&self) -> &Path {
+        &self.path
     }
 }
 


### PR DESCRIPTION
Implement `Deref<Target=Path>` for `MartianFileType`, similarly to how `PathBuf` does.
See <https://doc.rust-lang.org/stable/std/path/struct.PathBuf.html#impl-Deref-for-PathBuf>

- `martian_filetype`: Implement `Deref<Target=Path>`
- `martian_filetype_inner`: Implement `Deref<Target=Path>`
- `DelimitedFormat`: Implement `Deref<Target=Path>`
