### PR TITLE
Gzip: Add LazyRead and LazyWrite interfaces

### DIFF
--- a/martian-filetypes/src/gzip_file.rs
+++ b/martian-filetypes/src/gzip_file.rs
@@ -29,13 +29,14 @@
 //!     Ok(())
 //! }
 //! ```
-use crate::{ErrorContext, FileStorage, FileTypeIO};
+use crate::{ErrorContext, FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use martian::{Error, MartianFileType};
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
+use std::marker::PhantomData;
 
 crate::martian_filetype_inner! {
     /// A struct that wraps a basic `MartianFileType` and adds gzip compression
@@ -86,5 +87,281 @@ where
     }
     fn write_into<W: Write>(writer: W, item: &T) -> Result<(), Error> {
         <F as FileTypeIO<T>>::write_into(writer, item)
+    }
+}
+
+/// Helper struct to write items one by one into an Gzip file.
+/// Implements `LazyWrite` trait.
+pub struct LazyGzipWriter<L, T, W>
+where
+    L: LazyWrite<T, GzEncoder<W>>,
+    W: Write,
+{
+    inner: Option<L>,
+    phantom: PhantomData<(T, W)>,
+}
+
+impl<L, T, W> LazyWrite<T, W> for LazyGzipWriter<L, T, W>
+where
+    L: LazyWrite<T, GzEncoder<W>>,
+    W: Write,
+{
+    type FileType = Gzip<L::FileType>;
+    fn with_writer(writer: W) -> Result<Self, Error> {
+        Ok(LazyGzipWriter {
+            inner: Some(L::with_writer(GzEncoder::new(
+                writer,
+                Compression::default(),
+            ))?),
+            phantom: PhantomData,
+        })
+    }
+
+    fn write_item(&mut self, item: &T) -> Result<(), Error> {
+        self.inner.as_mut().unwrap().write_item(item)
+    }
+
+    fn finish(mut self) -> Result<W, Error> {
+        Ok(self._finished()?.unwrap())
+    }
+}
+
+impl<L, T, W> LazyGzipWriter<L, T, W>
+where
+    L: LazyWrite<T, GzEncoder<W>>,
+    W: Write,
+{
+    fn _finished(&mut self) -> Result<Option<W>, Error> {
+        self.inner
+            .take()
+            .map(|inner| Ok(inner.finish()?.finish()?))
+            .transpose()
+    }
+}
+
+impl<L, T, W> Drop for LazyGzipWriter<L, T, W>
+where
+    L: LazyWrite<T, GzEncoder<W>>,
+    W: Write,
+{
+    fn drop(&mut self) {
+        // Use the finish() method to capture the IO error on closing the writers
+        let _ = self._finished();
+    }
+}
+
+/// Iterator over individual items  within an gz file that
+/// stores a list of items.
+pub struct LazyGzipReader<L, T, R>
+where
+    L: LazyRead<T, GzDecoder<R>>,
+    R: Read,
+{
+    inner: L,
+    phantom: PhantomData<(T, R)>,
+}
+
+impl<L, T, R> LazyRead<T, R> for LazyGzipReader<L, T, R>
+where
+    L: LazyRead<T, GzDecoder<R>>,
+    R: Read,
+{
+    type FileType = Gzip<L::FileType>;
+    fn with_reader(reader: R) -> Result<Self, Error> {
+        Ok(LazyGzipReader {
+            inner: L::with_reader(GzDecoder::new(reader))?,
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<L, T, R> Iterator for LazyGzipReader<L, T, R>
+where
+    L: LazyRead<T, GzDecoder<R>>,
+    R: Read,
+{
+    type Item = Result<T, Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<F, T, W, R> LazyAgents<T, W, R> for Gzip<F>
+where
+    R: Read,
+    W: Write,
+    F: LazyAgents<T, GzEncoder<W>, GzDecoder<R>>,
+{
+    type LazyWriter = LazyGzipWriter<F::LazyWriter, T, W>;
+    type LazyReader = LazyGzipReader<F::LazyReader, T, R>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::json_file::JsonFile;
+    use crate::LazyFileTypeIO;
+    use std::path::{Path, PathBuf};
+
+    martian_derive::martian_filetype! {CompoundFile, "foo.bar"}
+
+    #[test]
+    fn test_gz_new() {
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file"),
+            Gzip {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file.json.gz")
+            }
+        );
+
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file.json"),
+            Gzip {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file.json.gz")
+            }
+        );
+
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file_json"),
+            Gzip {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file_json.json.gz")
+            }
+        );
+
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file.json.gz"),
+            Gzip {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file.json.gz")
+            }
+        );
+
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file.tmp"),
+            Gzip {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file.tmp.json.gz")
+            }
+        );
+
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file").as_ref(),
+            Path::new("/some/path/file.json.gz")
+        );
+    }
+
+    #[test]
+    fn test_gz_compound_extension() {
+        assert_eq!(Gzip::<CompoundFile>::extension(), "foo.bar.gz");
+        assert_eq!(
+            Gzip::<CompoundFile>::new("/some/path/", "file").as_ref(),
+            Path::new("/some/path/file.foo.bar.gz")
+        );
+        assert_eq!(
+            Gzip::<CompoundFile>::new("/some/path/", "file.foo").as_ref(),
+            Path::new("/some/path/file.foo.bar.gz")
+        );
+        assert_eq!(
+            Gzip::<CompoundFile>::new("/some/path/", "file.foo.bar").as_ref(),
+            Path::new("/some/path/file.foo.bar.gz")
+        );
+        assert_eq!(
+            Gzip::<CompoundFile>::new("/some/path/", "file.foo.bar.gz").as_ref(),
+            Path::new("/some/path/file.foo.bar.gz")
+        );
+    }
+
+    #[test]
+    fn test_gz_from() {
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file"),
+            Gzip::<JsonFile>::from("/some/path/file")
+        );
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file"),
+            Gzip::<JsonFile>::from("/some/path/file.json")
+        );
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file"),
+            Gzip::<JsonFile>::from("/some/path/file.json.gz")
+        );
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file.tmp"),
+            Gzip::<JsonFile>::from("/some/path/file.tmp.json.gz")
+        );
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file.tmp"),
+            Gzip::<JsonFile>::from("/some/path/file.tmp")
+        );
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file.tmp.json"),
+            Gzip::<JsonFile>::from("/some/path/file.tmp")
+        );
+    }
+
+    #[test]
+    fn test_gz_from_filetype() {
+        assert_eq!(
+            Gzip::<JsonFile>::new("/some/path/", "file"),
+            Gzip::from_filetype(JsonFile::new("/some/path/", "file"))
+        );
+    }
+
+    #[test]
+    fn test_gz_extension() {
+        assert_eq!(Gzip::<JsonFile>::extension(), "json.gz");
+    }
+
+    #[test]
+    fn test_json_gz_lazy_write() -> Result<(), Error> {
+        let dir = tempfile::tempdir()?;
+        let json_file = JsonFile::new(dir.path(), "file");
+        let file = Gzip::from_filetype(json_file);
+        let mut writer = file.lazy_writer()?;
+        for i in 0..10usize {
+            writer.write_item(&i)?;
+        }
+        writer.finish()?;
+        let reader = file.lazy_reader()?;
+        for (i, val) in reader.enumerate() {
+            let val: usize = val?;
+            assert_eq!(val, i);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_gz_lazy_write_no_finish() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = Gzip::<JsonFile>::new(dir.path(), "file");
+        let mut writer = file.lazy_writer().unwrap();
+        for i in 0..10 {
+            writer.write_item(&i).unwrap();
+        }
+        drop(writer);
+        let reader = file.lazy_reader().unwrap();
+        for (i, val) in reader.enumerate() {
+            let val: usize = val.unwrap();
+            assert_eq!(val, i);
+        }
+    }
+
+    #[test]
+    fn test_serialize() {
+        let gz_file = Gzip::<JsonFile>::new("/some/path/", "file");
+        let path = PathBuf::from("/some/path/file.json.gz");
+        assert_eq!(
+            serde_json::to_string(&gz_file).unwrap(),
+            serde_json::to_string(&path).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let gz_file: Gzip<JsonFile> = serde_json::from_str(r#""/some/path/file.json.gz""#).unwrap();
+        assert_eq!(gz_file, Gzip::<JsonFile>::new("/some/path/", "file"));
     }
 }


### PR DESCRIPTION
Add `LazyRead` and `LazyWrite` interfaces for `Gzip`.

`GzipFile` should probably use `MultiGzDecoder` rather than `GzDecoder`, which decodes only the first block of a block GZIP file.