### PR TITLE
Print full error context when a stage fails.

### DIFF
--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -286,7 +286,7 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
 fn report_error(md: &mut Metadata, e: &Error, is_assert: bool) {
     let bt = e.backtrace();
     let _ = md.stackvars(&bt.to_string());
-    let _ = write_errors(&format!("{:#}", e), is_assert);
+    let _ = write_errors(&format!("{e:#}"), is_assert);
 }
 
 fn get_generator_name() -> String {

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -286,7 +286,7 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
 fn report_error(md: &mut Metadata, e: &Error, is_assert: bool) {
     let bt = e.backtrace();
     let _ = md.stackvars(&bt.to_string());
-    let _ = write_errors(&e.to_string(), is_assert);
+    let _ = write_errors(&format!("{:#}", e), is_assert);
 }
 
 fn get_generator_name() -> String {


### PR DESCRIPTION
Tweaks the print directive when a stage fails to print the full `anyhow` error context chain.  Without this, the only message we get is the outermost context.

See https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations