### PR TITLE
Tidy up use statements

### DIFF
--- a/martian-filetypes/src/json_file.rs
+++ b/martian-filetypes/src/json_file.rs
@@ -79,13 +79,11 @@
 
 use crate::{FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
 use anyhow::format_err;
-use martian::Error;
-use martian::MartianFileType;
+use martian::{Error, MartianFileType};
 use martian_derive::martian_filetype;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use serde_json::de::Read as SerdeRead;
-use serde_json::de::{IoRead, StreamDeserializer};
+use serde_json::de::{IoRead, Read as SerdeRead, StreamDeserializer};
 use serde_json::ser::PrettyFormatter;
 use serde_json::Serializer;
 use std::fmt::Debug;

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -141,12 +141,10 @@
 //! - BamIndexFile
 
 use martian::{Error, MartianFileType};
-
-use std::fmt;
 use std::fs::File;
-use std::io;
 use std::iter::FromIterator;
 use std::path::PathBuf;
+use std::{fmt, io};
 
 pub mod bin_file;
 pub mod gzip_file;

--- a/martian-filetypes/src/lz4_file.rs
+++ b/martian-filetypes/src/lz4_file.rs
@@ -90,13 +90,12 @@
 //! }
 //! ```
 
-use crate::martian_filetype_inner;
-use crate::{ErrorContext, FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
+use crate::{
+    martian_filetype_inner, ErrorContext, FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite,
+};
 use martian::{Error, MartianFileType};
-
 use serde::{Deserialize, Serialize};
 use std::convert::From;
-
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -5,26 +5,21 @@
 //! For a guide style documentation and examples, visit: [https://martian-lang.github.io/martian-rust/](https://martian-lang.github.io/martian-rust/#/)
 //!
 
+pub use anyhow::Error;
+use anyhow::{format_err, Context};
+use backtrace::Backtrace;
+use log::{error, info};
 use std::collections::HashMap;
 use std::fmt::Write as FmtWrite;
 use std::fs::File;
-use std::io;
 use std::io::Write as IoWrite;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
-use std::panic;
 use std::path::Path;
-
-use backtrace::Backtrace;
-use log::{error, info};
-use time::format_description::{
-    modifier::{Day, Hour, Minute, Month, Second, Year},
-    Component, FormatItem,
-    FormatItem::Literal,
-};
+use std::{io, panic};
+use time::format_description::modifier::{Day, Hour, Minute, Month, Second, Year};
+use time::format_description::FormatItem::Literal;
+use time::format_description::{Component, FormatItem};
 use time::OffsetDateTime;
-
-pub use anyhow::Error;
-use anyhow::{format_err, Context};
 
 mod metadata;
 pub use metadata::*;
@@ -37,10 +32,9 @@ pub mod utils;
 pub use stage::*;
 
 pub mod mro;
+pub use log::LevelFilter;
 /// For convenience
 pub use mro::*;
-
-pub use log::LevelFilter;
 pub mod prelude;
 
 pub fn initialize(args: Vec<String>) -> Result<Metadata, Error> {

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -1,21 +1,17 @@
-use crate::DATE_FORMAT;
-use crate::{write_errors, Error};
-use time::{OffsetDateTime, UtcOffset};
-
+use crate::{write_errors, Error, DATE_FORMAT};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::map::Map;
 use serde_json::{self, Value};
-
 use std::any::type_name;
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fs::{rename, File, OpenOptions};
-use std::io::ErrorKind;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+use time::{OffsetDateTime, UtcOffset};
 
 pub type JsonDict = Map<String, Value>;
 pub type Json = Value;

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -13,8 +13,7 @@
 use crate::{Error, MartianVoid};
 use anyhow::format_err;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
 use std::hash::Hash;
 use std::path::{Path, PathBuf};

--- a/martian/src/prelude.rs
+++ b/martian/src/prelude.rs
@@ -10,7 +10,6 @@ pub use crate::stage::{
     MartianFileType, MartianMain, MartianMakePath, MartianRover, MartianStage, MartianVoid,
     RawMartianStage, Resource, StageDef,
 };
-pub use crate::Error;
-pub use crate::{martian_make_mro, MartianAdapter};
+pub use crate::{martian_make_mro, Error, MartianAdapter};
 pub use log::LevelFilter;
 pub use martian_stages;

--- a/martian/src/stage.rs
+++ b/martian/src/stage.rs
@@ -1,5 +1,4 @@
-use crate::metadata::Metadata;
-use crate::metadata::Version;
+use crate::metadata::{Metadata, Version};
 use crate::mro::{MartianStruct, MroMaker};
 use crate::utils::obj_encode;
 use crate::Error;

--- a/martian/src/utils.rs
+++ b/martian/src/utils.rs
@@ -7,8 +7,7 @@ use heck::ToUpperCamelCase;
 use serde::Serialize;
 use serde_json::Value;
 use std::os::unix::prelude::OsStrExt;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Shortcut function to encode an object as a Json dictionary
 pub fn obj_encode<T: Serialize>(v: &T) -> Result<JsonDict, Error> {


### PR DESCRIPTION
Tidy up `use` statements with
```sh
cargo fmt -- --config=group_imports=One,imports_granularity=Module
```
