### PR TITLE
Add ZSTD Compression Option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -538,6 +541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "martian-filetypes"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -655,6 +667,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "trybuild",
+ "zstd",
 ]
 
 [[package]]
@@ -756,6 +769,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plotters"
@@ -1376,3 +1395,33 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zstd"
+version = "0.12.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.5+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d9e60b4b1758206c238a10165fbcae3ca37b01744e394c463463f6529d23b"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]

--- a/martian-filetypes/Cargo.toml
+++ b/martian-filetypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-filetypes"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Sreenath Krishnan <sreenathk.89@gmail.com>"]
 edition = "2021"
 include = ["src/**/*"]
@@ -18,6 +18,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 lz4 = "1.23"
 csv = "1.2.1"
 flate2 = "1"
+zstd = "0.12.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -152,6 +152,7 @@ pub mod json_file;
 pub mod lz4_file;
 pub(crate) mod macros;
 pub mod tabular_file;
+pub mod zstd_file;
 
 /// Provide context for errors that may arise during read/write
 /// of a `MartianFileType`

--- a/martian-filetypes/src/zstd_file.rs
+++ b/martian-filetypes/src/zstd_file.rs
@@ -1,0 +1,437 @@
+//!
+//! This module defines an `zstd` wrapper over other basic filetypes. Most basic
+//! filetypes automatically inherit this behavior through the trait heirarchy.
+//!
+//!
+//! ## Simple read/write example
+//! The example shown below creates an zstd compressed json and bincode file.
+//! ```rust
+//! use martian_filetypes::FileTypeIO;
+//! use martian_filetypes::bin_file::BincodeFile;
+//! use martian_filetypes::json_file::JsonFile;
+//! use martian_filetypes::zstd_file::Zstd;
+//! use martian::Error;
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Debug, PartialEq, Serialize, Deserialize)]
+//! struct Chemistry {
+//!     name: String,
+//!     paired_end: bool,
+//! }
+//!
+//! fn main() -> Result<(), Error> {
+//!     let chem = Chemistry { name: "SCVDJ".into(), paired_end: true };
+//!     // --------------------- Json ----------------------------------
+//!     let zstd_json_file = Zstd::from_filetype(JsonFile::from("example")); // example.json.zst
+//!     // zstd_json_file has the type Zstd<JsonFile>
+//!     zstd_json_file.write(&chem)?; // Writes zstd compressed json file
+//!     let decoded: Chemistry = zstd_json_file.read()?;
+//!     assert_eq!(chem, decoded);
+//!     # std::fs::remove_file(zstd_json_file)?; // Remove the file (hidden from the doc)
+//!
+//!     // --------------------- Bincode ----------------------------------
+//!     let zstd_bin_file: Zstd<BincodeFile> = Zstd::from("example"); // example.bincode.zst
+//!     // Need to explcitly annotate the type id you are using from() or MartianFileType::new()
+//!     zstd_bin_file.write(&chem)?; // Writes zstd compressed bincode file
+//!     let decoded: Chemistry = zstd_bin_file.read()?;
+//!     assert_eq!(chem, decoded);
+//!     # std::fs::remove_file(zstd_bin_file)?; // Remove the file (hidden from the doc)
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Lazy read/write example
+//! The example below illustrates writing an integer one by one into an zstd compressed Bincode file
+//!
+//! #### IMPORTANT
+//! You need to explicitly call **`finish()`** on a lazy writer to complete the writing and capture
+//! the resulting errors. When the writer is dropped, we attempt to complete the writing, but
+//! ignoring the errors.
+//!
+//! ```rust
+//! use martian_filetypes::{FileTypeIO, LazyFileTypeIO, LazyWrite};
+//! use martian_filetypes::bin_file::BincodeFile;
+//! use martian_filetypes::zstd_file::Zstd;
+//! use martian::Error;
+//! use serde::{Serialize, Deserialize};
+//!
+//! fn main() -> Result<(), Error> {
+//!     let zstd_bin_file: Zstd<BincodeFile> = Zstd::from("example_lazy");
+//!     let mut zstd_writer = zstd_bin_file.lazy_writer()?;
+//!     // The type of the zstd_writer will be inferred by the compiler as:
+//!     // LazyZstdWriter<LazyBincodeWriter<i32, zstd::encoder::Encoder<BufWriter<File>>>, i32, BufWriter<File>>
+//!     // Clearly you want the compiler to figure this out.
+//!
+//!     // writer implements the trait `LazyWrite<_>`
+//!     for _ in 0..10_000 {
+//!         zstd_writer.write_item(&0i32)?;
+//!     }
+//!     zstd_writer.finish()?; // The file writing is not completed until finish() is called.
+//!     // IF YOU DON'T CALL finish(), THE FILE COULD BE INCOMPLETE UNTIL THE WRITER IS DROPPED
+//!
+//!     // For this extreme case of compression, the output file will be just 194 bytes, as opposed to
+//!     // 39KB uncompressed
+//!
+//!     let mut zstd_reader = zstd_bin_file.lazy_reader()?;
+//!     // The type of the zstd_reader will be inferred by the compiler as:
+//!     // LazyZstdReader<LazyBincodeReader<i32, zstd::decoder::Decoder<BufReader<File>>>, i32, BufReader<File>>
+//!     // Clearly you want the compiler to figure this out.
+//!     let mut n_val = 0;
+//!     // zstd_reader is an `Iterator` over values of type Result<`i32`, Error>
+//!     for (i, val) in zstd_reader.enumerate() {
+//!         let val: i32 = val?; // Helps with the type inference
+//!         assert_eq!(0i32, val);
+//!         n_val += 1;
+//!     }
+//!     assert_eq!(n_val, 10_000i32);
+//!     # std::fs::remove_file(zstd_bin_file)?; // Remove the file (hidden from the doc)
+//!     Ok(())
+//! }
+//! ```
+
+use crate::{
+    martian_filetype_inner, ErrorContext, FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite,
+};
+use martian::{Error, MartianFileType};
+use serde::{Deserialize, Serialize};
+use std::convert::From;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::marker::PhantomData;
+
+martian_filetype_inner! {
+    /// A struct that wraps a basic `MartianFileType` and adds zstd compression
+    /// capability.
+    pub struct Zstd, "zst"
+}
+
+impl<F> Zstd<F>
+where
+    F: MartianFileType,
+{
+    /// Create an Zstd wrapped filetype from a basic filetype
+    /// ```rust
+    /// use martian_filetypes::{zstd_file::Zstd, bin_file::BincodeFile};
+    /// let zstd_bin_file = Zstd::from_filetype(BincodeFile::from("example"));
+    /// assert_eq!(zstd_bin_file.as_ref(), std::path::Path::new("example.bincode.zst"));
+    /// ```
+    pub fn from_filetype(source: F) -> Self {
+        Self::from(source.as_ref())
+    }
+}
+
+impl<F, T> FileStorage<T> for Zstd<F> where F: FileStorage<T> {}
+
+impl<F, T> FileTypeIO<T> for Zstd<F>
+where
+    F: MartianFileType + FileTypeIO<T>,
+{
+    fn read(&self) -> Result<T, Error> {
+        let decoder = zstd::Decoder::new(self.buf_reader()?)?;
+        <Self as FileTypeIO<T>>::read_from(decoder).map_err(|e| {
+            let context = ErrorContext::ReadContext(self.as_ref().into(), e.to_string());
+            e.context(context)
+        })
+    }
+    fn read_from<R: Read>(reader: R) -> Result<T, Error> {
+        <F as FileTypeIO<T>>::read_from(reader)
+    }
+    fn write(&self, item: &T) -> Result<(), Error> {
+        // Default compression level and configuration
+        let mut encoder = zstd::Encoder::new(self.buf_writer()?, 0)?;
+        <Self as FileTypeIO<T>>::write_into(&mut encoder, item).map_err(|e| {
+            let context = ErrorContext::WriteContext(self.as_ref().into(), e.to_string());
+            e.context(context)
+        })?;
+        encoder.finish()?;
+        Ok(())
+    }
+    fn write_into<W: Write>(writer: W, item: &T) -> Result<(), Error> {
+        <F as FileTypeIO<T>>::write_into(writer, item)
+    }
+}
+
+/// Helper struct to write items one by one into an Zstd file.
+/// Implements `LazyWrite` trait.
+pub struct LazyZstdWriter<L, T, W>
+where
+    L: LazyWrite<T, zstd::Encoder<'static, W>>,
+    W: Write,
+{
+    inner: Option<L>,
+    phantom: PhantomData<(T, W)>,
+}
+
+impl<L, T, W> LazyWrite<T, W> for LazyZstdWriter<L, T, W>
+where
+    L: LazyWrite<T, zstd::Encoder<'static, W>>,
+    W: Write,
+{
+    type FileType = Zstd<L::FileType>;
+    fn with_writer(writer: W) -> Result<Self, Error> {
+        let encoder = zstd::Encoder::new(writer, 0)?;
+        let inner = L::with_writer(encoder)?;
+        Ok(LazyZstdWriter {
+            inner: Some(inner),
+            phantom: PhantomData,
+        })
+    }
+
+    fn write_item(&mut self, item: &T) -> Result<(), Error> {
+        match self.inner.as_mut() {
+            Some(inner) => inner.write_item(item),
+            None => unreachable!(),
+        }
+    }
+
+    fn finish(mut self) -> Result<W, Error> {
+        Ok(self._finished()?.unwrap())
+    }
+}
+
+impl<'a, L, T, W> LazyZstdWriter<L, T, W>
+where
+    L: LazyWrite<T, zstd::Encoder<'static, W>>,
+    W: Write,
+{
+    fn _finished(&mut self) -> Result<Option<W>, Error> {
+        match self.inner.take() {
+            Some(inner) => {
+                let encoder = inner.finish()?;
+                let result = encoder.finish()?;
+                Ok(Some(result))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl<L, T, W> Drop for LazyZstdWriter<L, T, W>
+where
+    L: LazyWrite<T, zstd::Encoder<'static, W>>,
+    W: Write,
+{
+    fn drop(&mut self) {
+        // Use the finish() method to capture the IO error on closing the writers
+        let _ = self._finished();
+    }
+}
+
+/// Iterator over individual items  within an zstd file that
+/// stores a list of items.
+pub struct LazyZstdReader<L, T, R>
+where
+    L: LazyRead<T, zstd::Decoder<'static, BufReader<R>>>,
+    R: BufRead,
+{
+    inner: L,
+    phantom: PhantomData<(R, T)>,
+}
+
+impl<L, T, R> LazyRead<T, R> for LazyZstdReader<L, T, R>
+where
+    L: LazyRead<T, zstd::Decoder<'static, BufReader<R>>>,
+    R: Read + BufRead,
+{
+    type FileType = Zstd<L::FileType>;
+    fn with_reader(reader: R) -> Result<Self, Error> {
+        let decoder = zstd::Decoder::new(reader)?;
+        let inner = L::with_reader(decoder)?;
+        Ok(LazyZstdReader {
+            inner,
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<'a, L, T, R> Iterator for LazyZstdReader<L, T, R>
+where
+    L: LazyRead<T, zstd::Decoder<'static, BufReader<R>>>,
+    R: BufRead,
+{
+    type Item = Result<T, Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<F, T, W, R> LazyAgents<T, W, R> for Zstd<F>
+where
+    R: BufRead,
+    W: Write,
+    F: LazyAgents<T, zstd::Encoder<'static, W>, zstd::Decoder<'static, BufReader<R>>>,
+{
+    type LazyWriter = LazyZstdWriter<F::LazyWriter, T, W>;
+    type LazyReader = LazyZstdReader<F::LazyReader, T, R>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::json_file::JsonFile;
+    use crate::LazyFileTypeIO;
+    use std::path::{Path, PathBuf};
+
+    martian_derive::martian_filetype! {CompoundFile, "foo.bar"}
+
+    #[test]
+    fn test_zstd_new() {
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file"),
+            Zstd {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file.json.zst")
+            }
+        );
+
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file.json"),
+            Zstd {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file.json.zst")
+            }
+        );
+
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file_json"),
+            Zstd {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file_json.json.zst")
+            }
+        );
+
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file.json.zst"),
+            Zstd {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file.json.zst")
+            }
+        );
+
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file.tmp"),
+            Zstd {
+                inner: PhantomData,
+                path: PathBuf::from("/some/path/file.tmp.json.zst")
+            }
+        );
+
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file").as_ref(),
+            Path::new("/some/path/file.json.zst")
+        );
+    }
+
+    #[test]
+    fn test_zstd_compound_extension() {
+        assert_eq!(Zstd::<CompoundFile>::extension(), "foo.bar.zst");
+        assert_eq!(
+            Zstd::<CompoundFile>::new("/some/path/", "file").as_ref(),
+            Path::new("/some/path/file.foo.bar.zst")
+        );
+        assert_eq!(
+            Zstd::<CompoundFile>::new("/some/path/", "file.foo").as_ref(),
+            Path::new("/some/path/file.foo.bar.zst")
+        );
+        assert_eq!(
+            Zstd::<CompoundFile>::new("/some/path/", "file.foo.bar").as_ref(),
+            Path::new("/some/path/file.foo.bar.zst")
+        );
+        assert_eq!(
+            Zstd::<CompoundFile>::new("/some/path/", "file.foo.bar.zst").as_ref(),
+            Path::new("/some/path/file.foo.bar.zst")
+        );
+    }
+
+    #[test]
+    fn test_zstd_from() {
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file"),
+            Zstd::<JsonFile>::from("/some/path/file")
+        );
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file"),
+            Zstd::<JsonFile>::from("/some/path/file.json")
+        );
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file"),
+            Zstd::<JsonFile>::from("/some/path/file.json.zst")
+        );
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file.tmp"),
+            Zstd::<JsonFile>::from("/some/path/file.tmp.json.zst")
+        );
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file.tmp"),
+            Zstd::<JsonFile>::from("/some/path/file.tmp")
+        );
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file.tmp.json"),
+            Zstd::<JsonFile>::from("/some/path/file.tmp")
+        );
+    }
+
+    #[test]
+    fn test_zstd_from_filetype() {
+        assert_eq!(
+            Zstd::<JsonFile>::new("/some/path/", "file"),
+            Zstd::from_filetype(JsonFile::new("/some/path/", "file"))
+        );
+    }
+
+    #[test]
+    fn test_zstd_extension() {
+        assert_eq!(Zstd::<JsonFile>::extension(), "json.zst");
+    }
+
+    #[test]
+    fn test_json_zstd_lazy_write() -> Result<(), Error> {
+        let dir = tempfile::tempdir()?;
+        let json_file = JsonFile::new(dir.path(), "file");
+        let file = Zstd::from_filetype(json_file);
+        let mut writer = file.lazy_writer()?;
+        for i in 0..10usize {
+            writer.write_item(&i)?;
+        }
+        writer.finish()?;
+        let reader = file.lazy_reader()?;
+        for (i, val) in reader.enumerate() {
+            let val: usize = val?;
+            assert_eq!(val, i);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_zstd_lazy_write_no_finish() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = Zstd::<JsonFile>::new(dir.path(), "file");
+        let mut writer = file.lazy_writer().unwrap();
+        for i in 0..10 {
+            writer.write_item(&i).unwrap();
+        }
+        drop(writer);
+        let reader = file.lazy_reader().unwrap();
+        for (i, val) in reader.enumerate() {
+            let val: usize = val.unwrap();
+            assert_eq!(val, i);
+        }
+    }
+
+    #[test]
+    fn test_serialize() {
+        let zstd_file = Zstd::<JsonFile>::new("/some/path/", "file");
+        let path = PathBuf::from("/some/path/file.json.zst");
+        assert_eq!(
+            serde_json::to_string(&zstd_file).unwrap(),
+            serde_json::to_string(&path).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let zstd_file: Zstd<JsonFile> =
+            serde_json::from_str(r#""/some/path/file.json.zst""#).unwrap();
+        assert_eq!(zstd_file, Zstd::<JsonFile>::new("/some/path/", "file"));
+    }
+}


### PR DESCRIPTION
Allows us to experiment with different compressors, modeled after `lz4_file`

Note this is a redo of https://github.com/martian-lang/martian-rust/pull/342 designed to go directly from master