### PR TITLE
Add explicit type parameters to serialization formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "martian-filetypes"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/martian-filetypes/Cargo.toml
+++ b/martian-filetypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "martian-filetypes"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Sreenath Krishnan <sreenathk.89@gmail.com>"]
 edition = "2021"
 include = ["src/**/*"]

--- a/martian-filetypes/Cargo.toml
+++ b/martian-filetypes/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 lz4 = "1.23"
 csv = "1.2.1"
 flate2 = "1"
-zstd = "0.12.3"
+zstd = "0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/martian-filetypes/Cargo.toml
+++ b/martian-filetypes/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 lz4 = "1.23"
 csv = "1.2.1"
 flate2 = "1"
-zstd = "0.12"
+zstd = "<0.13, >=0.11"
 
 [dev-dependencies]
 tempfile = "3"

--- a/martian-filetypes/benches/benchmarks.rs
+++ b/martian-filetypes/benches/benchmarks.rs
@@ -3,7 +3,7 @@ use martian::MartianFileType;
 use martian_filetypes::bin_file::BincodeFile;
 use martian_filetypes::json_file::JsonFile;
 use martian_filetypes::lz4_file::Lz4;
-use martian_filetypes::{FileTypeIO, LazyFileTypeIO, LazyWrite};
+use martian_filetypes::{FileTypeIO, FileTypeRead, FileTypeWrite, LazyFileTypeIO, LazyWrite};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Clone)]

--- a/martian-filetypes/benches/benchmarks.rs
+++ b/martian-filetypes/benches/benchmarks.rs
@@ -100,22 +100,22 @@ where
 
 fn json_lazy_read_bench(c: &mut Criterion) {
     let data: Vec<_> = vec![Foo::default(); 100_000];
-    lazy_read_bench::<JsonFile, _>(c, data, "bench-json-lazy-read");
+    lazy_read_bench::<JsonFile<_>, _>(c, data, "bench-json-lazy-read");
 }
 
 fn bincode_lazy_read_bench(c: &mut Criterion) {
     let data: Vec<_> = vec![Foo::default(); 100_000];
-    lazy_read_bench::<BincodeFile, _>(c, data, "bench-bincode-lazy-read");
+    lazy_read_bench::<BincodeFile<_>, _>(c, data, "bench-bincode-lazy-read");
 }
 
 fn json_lazy_write_bench(c: &mut Criterion) {
     let data: Vec<_> = vec![Foo::default(); 100_000];
-    lazy_write_bench::<JsonFile, _>(c, data, "bench-json-lazy-write");
+    lazy_write_bench::<JsonFile<_>, _>(c, data, "bench-json-lazy-write");
 }
 
 fn bincode_lazy_write_bench(c: &mut Criterion) {
     let data: Vec<_> = vec![Foo::default(); 100_000];
-    lazy_write_bench::<BincodeFile, _>(c, data, "bench-bincode-lazy-write");
+    lazy_write_bench::<BincodeFile<_>, _>(c, data, "bench-bincode-lazy-write");
 }
 
 criterion_group!(

--- a/martian-filetypes/src/bin_file.rs
+++ b/martian-filetypes/src/bin_file.rs
@@ -79,7 +79,7 @@
 //! }
 //! ```
 
-use crate::{FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
+use crate::{FileTypeIO, LazyAgents, LazyRead, LazyWrite};
 use anyhow::format_err;
 use martian::{Error, MartianFileType};
 use martian_derive::martian_filetype;
@@ -93,7 +93,7 @@ use std::iter::Iterator;
 use std::marker::PhantomData;
 
 martian_filetype! {Bincode, "bincode"}
-impl<T> FileStorage<T> for Bincode where T: Serialize + DeserializeOwned {}
+
 pub type BincodeFile = BinaryFormat<Bincode>;
 
 crate::martian_filetype_inner! {
@@ -101,14 +101,12 @@ crate::martian_filetype_inner! {
     pub struct BinaryFormat, "bincode"
 }
 
-impl<F, T> FileStorage<T> for BinaryFormat<F> where F: MartianFileType + FileStorage<T> {}
-
 /// Any type `T` that can be deserialized implements `load()` from a `BincodeFile`
 /// TODO: Include the TypeId here?
 impl<T, F> FileTypeIO<T> for BinaryFormat<F>
 where
     T: Any + Serialize + DeserializeOwned,
-    F: FileStorage<T> + Debug,
+    F: Debug + MartianFileType,
 {
     fn read_from<R: Read>(mut reader: R) -> Result<T, Error> {
         fn check_type(
@@ -156,7 +154,7 @@ enum FileMode {
 /// stores a list of items.
 pub struct LazyBincodeReader<T, F = Bincode, R = BufReader<File>>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     R: Read,
     T: Any + DeserializeOwned,
 {
@@ -169,7 +167,7 @@ where
 
 impl<T, F, R> LazyRead<T, R> for LazyBincodeReader<T, F, R>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     R: Read,
     T: Any + Serialize + DeserializeOwned,
 {
@@ -213,7 +211,7 @@ where
 
 impl<T, F, R> Iterator for LazyBincodeReader<T, F, R>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     R: Read,
     T: Any + DeserializeOwned,
 {
@@ -275,7 +273,7 @@ struct LazyMarker<T>(PhantomData<T>);
 /// stores a list of items
 pub struct LazyBincodeWriter<T, F = Bincode, W = BufWriter<File>>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     W: Write,
     T: Any + Serialize,
 {
@@ -287,7 +285,7 @@ where
 
 impl<T, F, W> LazyWrite<T, W> for LazyBincodeWriter<T, F, W>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     W: Write,
     T: Any + Serialize,
 {
@@ -314,7 +312,7 @@ where
 
 impl<T, F, W, R> LazyAgents<T, W, R> for BinaryFormat<F>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     R: Read,
     W: Write,
     T: Any + Serialize + DeserializeOwned,

--- a/martian-filetypes/src/bin_file.rs
+++ b/martian-filetypes/src/bin_file.rs
@@ -104,7 +104,7 @@ pub type BincodeFile<T> = BinaryFormat<Bincode, T>;
 impl<T, F> FileTypeIO<T> for BinaryFormat<F, T>
 where
     T: Any + Serialize + DeserializeOwned,
-    F: Debug + MartianFileType,
+    F: MartianFileType,
 {
     fn read_from<R: Read>(mut reader: R) -> Result<T, Error> {
         fn check_type(

--- a/martian-filetypes/src/gzip_file.rs
+++ b/martian-filetypes/src/gzip_file.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-crate::martian_filetype_inner! {
+crate::martian_filetype_decorator! {
     /// A struct that wraps a basic `MartianFileType` and adds gzip compression
     /// capability.
     pub struct Gzip, "gz"
@@ -51,7 +51,7 @@ where
     /// Create an Gzip wrapped filetype from a basic filetype
     /// ```rust
     /// use martian_filetypes::{gzip_file::Gzip, bin_file::BincodeFile};
-    /// let gz_bin_file = Gzip::from_filetype(BincodeFile::from("example"));
+    /// let gz_bin_file = Gzip::from_filetype(BincodeFile::<()>::from("example"));
     /// assert_eq!(gz_bin_file.as_ref(), std::path::Path::new("example.bincode.gz"));
     /// ```
     pub fn from_filetype(source: F) -> Self {
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn test_gz_new() {
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file"),
+            Gzip::<JsonFile<()>>::new("/some/path/", "file"),
             Gzip {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.gz")
@@ -214,7 +214,7 @@ mod tests {
         );
 
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file.json"),
+            Gzip::<JsonFile<()>>::new("/some/path/", "file.json"),
             Gzip {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.gz")
@@ -222,7 +222,7 @@ mod tests {
         );
 
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file_json"),
+            Gzip::<JsonFile<()>>::new("/some/path/", "file_json"),
             Gzip {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file_json.json.gz")
@@ -230,7 +230,7 @@ mod tests {
         );
 
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file.json.gz"),
+            Gzip::<JsonFile<()>>::new("/some/path/", "file.json.gz"),
             Gzip {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.gz")
@@ -238,7 +238,7 @@ mod tests {
         );
 
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file.tmp"),
+            Gzip::<JsonFile<()>>::new("/some/path/", "file.tmp"),
             Gzip {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.tmp.json.gz")
@@ -246,7 +246,7 @@ mod tests {
         );
 
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file").as_ref(),
+            Gzip::<JsonFile<()>>::new("/some/path/", "file").as_ref(),
             Path::new("/some/path/file.json.gz")
         );
     }
@@ -275,42 +275,42 @@ mod tests {
     #[test]
     fn test_gz_from() {
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file"),
-            Gzip::<JsonFile>::from("/some/path/file")
+            Gzip::<JsonFile<()>>::new("/some/path/", "file"),
+            Gzip::<JsonFile<()>>::from("/some/path/file")
         );
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file"),
-            Gzip::<JsonFile>::from("/some/path/file.json")
+            Gzip::<JsonFile<()>>::new("/some/path/", "file"),
+            Gzip::<JsonFile<()>>::from("/some/path/file.json")
         );
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file"),
-            Gzip::<JsonFile>::from("/some/path/file.json.gz")
+            Gzip::<JsonFile<()>>::new("/some/path/", "file"),
+            Gzip::<JsonFile<()>>::from("/some/path/file.json.gz")
         );
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file.tmp"),
-            Gzip::<JsonFile>::from("/some/path/file.tmp.json.gz")
+            Gzip::<JsonFile<()>>::new("/some/path/", "file.tmp"),
+            Gzip::<JsonFile<()>>::from("/some/path/file.tmp.json.gz")
         );
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file.tmp"),
-            Gzip::<JsonFile>::from("/some/path/file.tmp")
+            Gzip::<JsonFile<()>>::new("/some/path/", "file.tmp"),
+            Gzip::<JsonFile<()>>::from("/some/path/file.tmp")
         );
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file.tmp.json"),
-            Gzip::<JsonFile>::from("/some/path/file.tmp")
+            Gzip::<JsonFile<()>>::new("/some/path/", "file.tmp.json"),
+            Gzip::<JsonFile<()>>::from("/some/path/file.tmp")
         );
     }
 
     #[test]
     fn test_gz_from_filetype() {
         assert_eq!(
-            Gzip::<JsonFile>::new("/some/path/", "file"),
+            Gzip::<JsonFile<()>>::new("/some/path/", "file"),
             Gzip::from_filetype(JsonFile::new("/some/path/", "file"))
         );
     }
 
     #[test]
     fn test_gz_extension() {
-        assert_eq!(Gzip::<JsonFile>::extension(), "json.gz");
+        assert_eq!(Gzip::<JsonFile<()>>::extension(), "json.gz");
     }
 
     #[test]
@@ -334,7 +334,7 @@ mod tests {
     #[test]
     fn test_json_gz_lazy_write_no_finish() {
         let dir = tempfile::tempdir().unwrap();
-        let file = Gzip::<JsonFile>::new(dir.path(), "file");
+        let file: Gzip<JsonFile<_>> = Gzip::new(dir.path(), "file");
         let mut writer = file.lazy_writer().unwrap();
         for i in 0..10 {
             writer.write_item(&i).unwrap();
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_serialize() {
-        let gz_file = Gzip::<JsonFile>::new("/some/path/", "file");
+        let gz_file: Gzip<JsonFile<()>> = Gzip::new("/some/path/", "file");
         let path = PathBuf::from("/some/path/file.json.gz");
         assert_eq!(
             serde_json::to_string(&gz_file).unwrap(),
@@ -359,7 +359,8 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let gz_file: Gzip<JsonFile> = serde_json::from_str(r#""/some/path/file.json.gz""#).unwrap();
-        assert_eq!(gz_file, Gzip::<JsonFile>::new("/some/path/", "file"));
+        let gz_file: Gzip<JsonFile<()>> =
+            serde_json::from_str(r#""/some/path/file.json.gz""#).unwrap();
+        assert_eq!(gz_file, Gzip::new("/some/path/", "file"));
     }
 }

--- a/martian-filetypes/src/gzip_file.rs
+++ b/martian-filetypes/src/gzip_file.rs
@@ -29,7 +29,7 @@
 //!     Ok(())
 //! }
 //! ```
-use crate::{ErrorContext, FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
+use crate::{ErrorContext, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -58,8 +58,6 @@ where
         Self::from(source.as_ref())
     }
 }
-
-impl<F, T> FileStorage<T> for Gzip<F> where F: FileStorage<T> {}
 
 impl<F, T> FileTypeIO<T> for Gzip<F>
 where

--- a/martian-filetypes/src/json_file.rs
+++ b/martian-filetypes/src/json_file.rs
@@ -399,6 +399,17 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_json_lazy_read_not_vec() -> Result<(), Error> {
+        let dir = tempfile::tempdir()?;
+        let json_file = JsonFile::new(dir.path(), "lazy_test");
+        let input = String::from("Hello");
+        json_file.write(&input)?;
+        let reader_wrong_type: JsonFile<Vec<i32>> = JsonFile::new(dir.path(), "lazy_test");
+        assert!(reader_wrong_type.lazy_reader().is_err());
+        Ok(())
+    }
+
     fn serde_lazy_roundtrip_check<T>(input: &[T]) -> Result<(), Error>
     where
         T: Serialize + DeserializeOwned + PartialEq,

--- a/martian-filetypes/src/json_file.rs
+++ b/martian-filetypes/src/json_file.rs
@@ -77,7 +77,7 @@
 //! }
 //! ```
 
-use crate::{FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
+use crate::{FileTypeIO, LazyAgents, LazyRead, LazyWrite};
 use anyhow::format_err;
 use martian::{Error, MartianFileType};
 use martian_derive::martian_filetype;
@@ -92,7 +92,6 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::marker::PhantomData;
 
 martian_filetype! {Json, "json"}
-impl<T> FileStorage<T> for Json where T: Serialize + DeserializeOwned {}
 
 pub type JsonFile = JsonFormat<Json>;
 
@@ -101,15 +100,13 @@ crate::martian_filetype_inner! {
     pub struct JsonFormat, "json"
 }
 
-impl<F, T> FileStorage<T> for JsonFormat<F> where F: MartianFileType + FileStorage<T> {}
-
 /// Any type `T` that can be deserialized implements `read()` from a `JsonFile`
 /// Any type `T` that can be serialized can be saved as a `JsonFile`.
 /// The saved JsonFile will be pretty formatted using 4 space indentation.
 impl<F, T> FileTypeIO<T> for JsonFormat<F>
 where
     T: Serialize + DeserializeOwned,
-    F: MartianFileType + FileStorage<T> + Debug,
+    F: MartianFileType + Debug,
 {
     fn read_from<R: Read>(reader: R) -> Result<T, Error> {
         Ok(serde_json::from_reader(reader)?)
@@ -127,7 +124,7 @@ where
 /// stores a list of items.
 pub struct LazyJsonReader<T, F = Json, R = BufReader<File>>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     R: Read,
     T: Serialize + DeserializeOwned,
 {
@@ -138,7 +135,7 @@ where
 
 impl<T, F, R> LazyRead<T, R> for LazyJsonReader<T, F, R>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     R: Read,
     T: Serialize + DeserializeOwned,
 {
@@ -161,7 +158,7 @@ where
 
 impl<T, F, R> Iterator for LazyJsonReader<T, F, R>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     R: Read,
     T: Serialize + DeserializeOwned,
 {
@@ -212,7 +209,7 @@ enum WriterState {
 /// stores a list of items.
 pub struct LazyJsonWriter<T, F = Json, W = BufWriter<File>>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     W: Write,
     T: Serialize + DeserializeOwned,
 {
@@ -225,7 +222,7 @@ where
 
 impl<T, F, W> LazyWrite<T, W> for LazyJsonWriter<T, F, W>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     W: Write,
     T: Serialize + DeserializeOwned,
 {
@@ -271,7 +268,7 @@ where
 
 impl<T, F, W> LazyJsonWriter<T, F, W>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     W: Write,
     T: Serialize + DeserializeOwned,
 {
@@ -291,7 +288,7 @@ where
 
 impl<F, T, W, R> LazyAgents<T, W, R> for JsonFormat<F>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     R: Read,
     W: Write,
     T: Serialize + DeserializeOwned,
@@ -302,7 +299,7 @@ where
 
 impl<T, F, W> Drop for LazyJsonWriter<T, F, W>
 where
-    F: MartianFileType + FileStorage<Vec<T>>,
+    F: MartianFileType,
     W: Write,
     T: Serialize + DeserializeOwned,
 {

--- a/martian-filetypes/src/json_file.rs
+++ b/martian-filetypes/src/json_file.rs
@@ -106,7 +106,7 @@ pub type JsonFile<T> = JsonFormat<Json, T>;
 impl<F, T> FileTypeIO<T> for JsonFormat<F, T>
 where
     T: Serialize + DeserializeOwned,
-    F: MartianFileType + Debug,
+    F: MartianFileType,
 {
     fn read_from<R: Read>(reader: R) -> Result<T, Error> {
         Ok(serde_json::from_reader(reader)?)

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -190,12 +190,6 @@ where
     }
 }
 
-/// A `MartianFileType` `F` is a `FileStorage<T>` if it is valid to
-/// save an object of type `T` in a file with the extension `F::extension()`
-/// This trait will give us compile time guarantees on whether we are
-/// writing into or reading from a file type into an invalid type
-pub trait FileStorage<T>: MartianFileType {}
-
 /// A trait that represents a `MartianFileType` that can be read into
 /// memory as type `T` or written from type `T`. Use the `read()` and
 /// `write()` methods to achieve these.
@@ -203,7 +197,7 @@ pub trait FileStorage<T>: MartianFileType {}
 /// If you want to implement this trait for a custom filetype, read
 /// the inline comments on which functions are provided and which
 /// are required.
-pub trait FileTypeIO<T>: MartianFileType + fmt::Debug + FileStorage<T> {
+pub trait FileTypeIO<T>: MartianFileType {
     /// Read the `MartianFileType` as type `T`
     /// The default implementation should work in most cases. It is recommended
     /// **not** to implement this for a custom filetype in general, instead implement
@@ -251,7 +245,7 @@ pub trait FileTypeIO<T>: MartianFileType + fmt::Debug + FileStorage<T> {
 /// read or written. For example, you might have a fasta file and you might
 /// want to iterate over individual sequences in the file without
 /// reading everything into memory at once.
-pub trait LazyFileTypeIO<T>: MartianFileType + Sized + FileStorage<Vec<T>> {
+pub trait LazyFileTypeIO<T>: MartianFileType + Sized {
     type Reader: io::Read;
     type Writer: io::Write;
 
@@ -305,7 +299,7 @@ pub trait LazyAgents<T, W: io::Write, R: io::Read>: Sized + MartianFileType {
 
 impl<F, T> LazyFileTypeIO<T> for F
 where
-    F: LazyAgents<T, io::BufWriter<File>, io::BufReader<File>> + FileStorage<Vec<T>>,
+    F: LazyAgents<T, io::BufWriter<File>, io::BufReader<File>>,
 {
     type Writer = io::BufWriter<File>;
     type Reader = io::BufReader<File>;

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -57,26 +57,15 @@
 //! generate a compiler error saying you are trying to deserialize from an incompatible file.
 //! This crate makes use of `MartianFiletype` trait in order to facilitate this.
 //!
-//! There are two concepts involved here:
-//! 1. **Representation**: How is the object represented on disk? E.g. json/bincode/csv etc.
-//! 2. **Validity**: Is it valid to deserialize this file as a type `T`?
-//!
-//! Let `F` be a `MartianFileType` and `T` be a type in rust which we want to store on-disk.
-//! ### Validity
-//! If `F: FileStorage<T>`, then it is **valid** to store some representation of the type `T`
-//! in the filetype `F`.
-//!
-//! ### Representation
 //! If `F: FileTypeIO<T>`, then a concrete representation of type `T` can be written to [read from]
 //! disk. `MartianFiletype`s which implement this trait are called `Formats`. For example, we can
-//! define a `JsonFormat<F>`, which can write out any type `T` onto disk as json as long as T is
-//! serializable and `F: FileStorage<T>`.
+//! define a `JsonFormat<F, T>`, which can write out the type `T` onto disk.
 //!
 //! ```
 //! # use anyhow ::Error;
 //! # use martian_derive::martian_filetype;
 //! # use martian_filetypes::json_file::JsonFormat;
-//! # use martian_filetypes::{FileStorage, FileTypeIO};
+//! # use martian_filetypes::{FileTypeIO};
 //! # use serde::{Deserialize, Serialize};
 //! # use serde_json;
 //! #[derive(Debug, Serialize, Deserialize)]
@@ -84,7 +73,6 @@
 //!     id: usize,
 //! }
 //! martian_filetype! {FeatureFile, "feat"}
-//! impl FileStorage<Feature> for FeatureFile {} // VALIDITY
 //!
 //! #[derive(Debug, Serialize, Deserialize)]
 //! struct Creature {
@@ -94,8 +82,7 @@
 //! # fn main() -> Result<(), Error> {
 //! let feature = Feature { id: 5 };
 //! let creature = Creature { id: 10 };
-//! // JsonFormat<_> is the REPRESENTATION
-//! let feat_file: JsonFormat<FeatureFile> = JsonFormat::from("feature"); // feature.feat.json
+//! let feat_file: JsonFormat<FeatureFile, Feature> = JsonFormat::from("feature"); // feature.feat.json
 //! feat_file.write(&feature)?;
 //! // feat_file.write(&creature)?; // This is a compiler error
 //! // let _: Creature = feat_file.read()?; // This is a compiler error
@@ -131,14 +118,6 @@
 //!
 //! ## Examples
 //! Look at the individual filetype modules for examples.
-//!
-//! ## TODO
-//! - FastaFile
-//! - FastaIndexFile
-//! - FastqFile
-//! - CsvFile
-//! - BamFile
-//! - BamIndexFile
 
 use martian::{Error, MartianFileType};
 use std::fs::File;

--- a/martian-filetypes/src/lz4_file.rs
+++ b/martian-filetypes/src/lz4_file.rs
@@ -30,7 +30,7 @@
 //!     # std::fs::remove_file(lz4_json_file)?; // Remove the file (hidden from the doc)
 //!
 //!     // --------------------- Bincode ----------------------------------
-//!     let lz4_bin_file: Lz4<BincodeFile> = Lz4::from("example"); // example.bincode.lz4
+//!     let lz4_bin_file: Lz4<BincodeFile<_>> = Lz4::from("example"); // example.bincode.lz4
 //!     // Need to explcitly annotate the type id you are using from() or MartianFileType::new()
 //!     lz4_bin_file.write(&chem)?; // Writes lz4 compressed bincode file
 //!     let decoded: Chemistry = lz4_bin_file.read()?;
@@ -57,7 +57,7 @@
 //! use serde::{Serialize, Deserialize};
 //!
 //! fn main() -> Result<(), Error> {
-//!     let lz4_bin_file: Lz4<BincodeFile> = Lz4::from("example_lazy");
+//!     let lz4_bin_file: Lz4<BincodeFile<_>> = Lz4::from("example_lazy");
 //!     let mut lz4_writer = lz4_bin_file.lazy_writer()?;
 //!     // The type of the lz4_writer will be inferred by the compiler as:
 //!     // LazyLz4Writer<LazyBincodeWriter<i32, lz4::encoder::Encoder<BufWriter<File>>>, i32, BufWriter<File>>
@@ -90,14 +90,16 @@
 //! }
 //! ```
 
-use crate::{martian_filetype_inner, ErrorContext, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
+use crate::{
+    martian_filetype_decorator, ErrorContext, FileTypeIO, LazyAgents, LazyRead, LazyWrite,
+};
 use martian::{Error, MartianFileType};
 use serde::{Deserialize, Serialize};
 use std::convert::From;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-martian_filetype_inner! {
+martian_filetype_decorator! {
     /// A struct that wraps a basic `MartianFileType` and adds lz4 compression
     /// capability.
     pub struct Lz4, "lz4"
@@ -110,7 +112,7 @@ where
     /// Create an Lz4 wrapped filetype from a basic filetype
     /// ```rust
     /// use martian_filetypes::{lz4_file::Lz4, bin_file::BincodeFile};
-    /// let lz4_bin_file = Lz4::from_filetype(BincodeFile::from("example"));
+    /// let lz4_bin_file = Lz4::from_filetype(BincodeFile::<()>::from("example"));
     /// assert_eq!(lz4_bin_file.as_ref(), std::path::Path::new("example.bincode.lz4"));
     /// ```
     pub fn from_filetype(source: F) -> Self {
@@ -274,7 +276,7 @@ mod tests {
     #[test]
     fn test_lz4_new() {
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file"),
+            Lz4::<JsonFile<()>>::new("/some/path/", "file"),
             Lz4 {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.lz4")
@@ -282,7 +284,7 @@ mod tests {
         );
 
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file.json"),
+            Lz4::<JsonFile<()>>::new("/some/path/", "file.json"),
             Lz4 {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.lz4")
@@ -290,7 +292,7 @@ mod tests {
         );
 
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file_json"),
+            Lz4::<JsonFile<()>>::new("/some/path/", "file_json"),
             Lz4 {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file_json.json.lz4")
@@ -298,7 +300,7 @@ mod tests {
         );
 
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file.json.lz4"),
+            Lz4::<JsonFile<()>>::new("/some/path/", "file.json.lz4"),
             Lz4 {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.lz4")
@@ -306,7 +308,7 @@ mod tests {
         );
 
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file.tmp"),
+            Lz4::<JsonFile<()>>::new("/some/path/", "file.tmp"),
             Lz4 {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.tmp.json.lz4")
@@ -314,7 +316,7 @@ mod tests {
         );
 
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file").as_ref(),
+            Lz4::<JsonFile<()>>::new("/some/path/", "file").as_ref(),
             Path::new("/some/path/file.json.lz4")
         );
     }
@@ -343,42 +345,42 @@ mod tests {
     #[test]
     fn test_lz4_from() {
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file"),
-            Lz4::<JsonFile>::from("/some/path/file")
+            Lz4::<JsonFile<()>>::new("/some/path/", "file"),
+            Lz4::<JsonFile<()>>::from("/some/path/file")
         );
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file"),
-            Lz4::<JsonFile>::from("/some/path/file.json")
+            Lz4::<JsonFile<()>>::new("/some/path/", "file"),
+            Lz4::<JsonFile<()>>::from("/some/path/file.json")
         );
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file"),
-            Lz4::<JsonFile>::from("/some/path/file.json.lz4")
+            Lz4::<JsonFile<()>>::new("/some/path/", "file"),
+            Lz4::<JsonFile<()>>::from("/some/path/file.json.lz4")
         );
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file.tmp"),
-            Lz4::<JsonFile>::from("/some/path/file.tmp.json.lz4")
+            Lz4::<JsonFile<()>>::new("/some/path/", "file.tmp"),
+            Lz4::<JsonFile<()>>::from("/some/path/file.tmp.json.lz4")
         );
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file.tmp"),
-            Lz4::<JsonFile>::from("/some/path/file.tmp")
+            Lz4::<JsonFile<()>>::new("/some/path/", "file.tmp"),
+            Lz4::<JsonFile<()>>::from("/some/path/file.tmp")
         );
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file.tmp.json"),
-            Lz4::<JsonFile>::from("/some/path/file.tmp")
+            Lz4::<JsonFile<()>>::new("/some/path/", "file.tmp.json"),
+            Lz4::<JsonFile<()>>::from("/some/path/file.tmp")
         );
     }
 
     #[test]
     fn test_lz4_from_filetype() {
         assert_eq!(
-            Lz4::<JsonFile>::new("/some/path/", "file"),
+            Lz4::<JsonFile<()>>::new("/some/path/", "file"),
             Lz4::from_filetype(JsonFile::new("/some/path/", "file"))
         );
     }
 
     #[test]
     fn test_lz4_extension() {
-        assert_eq!(Lz4::<JsonFile>::extension(), "json.lz4");
+        assert_eq!(Lz4::<JsonFile<()>>::extension(), "json.lz4");
     }
 
     #[test]
@@ -402,7 +404,7 @@ mod tests {
     #[test]
     fn test_json_lz4_lazy_write_no_finish() {
         let dir = tempfile::tempdir().unwrap();
-        let file = Lz4::<JsonFile>::new(dir.path(), "file");
+        let file = Lz4::<JsonFile<Vec<usize>>>::new(dir.path(), "file");
         let mut writer = file.lazy_writer().unwrap();
         for i in 0..10 {
             writer.write_item(&i).unwrap();
@@ -417,7 +419,7 @@ mod tests {
 
     #[test]
     fn test_serialize() {
-        let lz4_file = Lz4::<JsonFile>::new("/some/path/", "file");
+        let lz4_file = Lz4::<JsonFile<()>>::new("/some/path/", "file");
         let path = PathBuf::from("/some/path/file.json.lz4");
         assert_eq!(
             serde_json::to_string(&lz4_file).unwrap(),
@@ -427,8 +429,8 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let lz4_file: Lz4<JsonFile> =
+        let lz4_file: Lz4<JsonFile<()>> =
             serde_json::from_str(r#""/some/path/file.json.lz4""#).unwrap();
-        assert_eq!(lz4_file, Lz4::<JsonFile>::new("/some/path/", "file"));
+        assert_eq!(lz4_file, Lz4::new("/some/path/", "file"));
     }
 }

--- a/martian-filetypes/src/lz4_file.rs
+++ b/martian-filetypes/src/lz4_file.rs
@@ -6,7 +6,7 @@
 //! ## Simple read/write example
 //! The example shown below creates an lz4 compressed json and bincode file.
 //! ```rust
-//! use martian_filetypes::FileTypeIO;
+//! use martian_filetypes::{FileTypeRead, FileTypeWrite};
 //! use martian_filetypes::bin_file::BincodeFile;
 //! use martian_filetypes::json_file::JsonFile;
 //! use martian_filetypes::lz4_file::Lz4;
@@ -50,7 +50,7 @@
 //! ignoring the errors.
 //!
 //! ```rust
-//! use martian_filetypes::{FileTypeIO, LazyFileTypeIO, LazyWrite};
+//! use martian_filetypes::{FileTypeRead, FileTypeWrite, LazyFileTypeIO, LazyWrite};
 //! use martian_filetypes::bin_file::BincodeFile;
 //! use martian_filetypes::lz4_file::Lz4;
 //! use martian::Error;
@@ -91,7 +91,8 @@
 //! ```
 
 use crate::{
-    martian_filetype_decorator, ErrorContext, FileTypeIO, LazyAgents, LazyRead, LazyWrite,
+    martian_filetype_decorator, ErrorContext, FileTypeIO, FileTypeRead, FileTypeWrite, LazyAgents,
+    LazyRead, LazyWrite,
 };
 use martian::{Error, MartianFileType};
 use serde::{Deserialize, Serialize};
@@ -120,24 +121,30 @@ where
     }
 }
 
-impl<F, T> FileTypeIO<T> for Lz4<F>
+impl<F, T> FileTypeRead<T> for Lz4<F>
 where
     F: MartianFileType + FileTypeIO<T>,
 {
     fn read(&self) -> Result<T, Error> {
         let decoder = lz4::Decoder::new(self.buf_reader()?)?;
-        <Self as FileTypeIO<T>>::read_from(decoder).map_err(|e| {
+        <Self as FileTypeRead<T>>::read_from(decoder).map_err(|e| {
             let context = ErrorContext::ReadContext(self.as_ref().into(), e.to_string());
             e.context(context)
         })
     }
     fn read_from<R: Read>(reader: R) -> Result<T, Error> {
-        <F as FileTypeIO<T>>::read_from(reader)
+        <F as FileTypeRead<T>>::read_from(reader)
     }
+}
+
+impl<F, T> FileTypeWrite<T> for Lz4<F>
+where
+    F: MartianFileType + FileTypeIO<T>,
+{
     fn write(&self, item: &T) -> Result<(), Error> {
         // Default compression level and configuration
         let mut encoder = lz4::EncoderBuilder::new().build(self.buf_writer()?)?;
-        <Self as FileTypeIO<T>>::write_into(&mut encoder, item).map_err(|e| {
+        <Self as FileTypeWrite<T>>::write_into(&mut encoder, item).map_err(|e| {
             let context = ErrorContext::WriteContext(self.as_ref().into(), e.to_string());
             e.context(context)
         })?;
@@ -145,10 +152,9 @@ where
         Ok(result?)
     }
     fn write_into<W: Write>(writer: W, item: &T) -> Result<(), Error> {
-        <F as FileTypeIO<T>>::write_into(writer, item)
+        <F as FileTypeWrite<T>>::write_into(writer, item)
     }
 }
-
 /// Helper struct to write items one by one into an Lz4 file.
 /// Implements `LazyWrite` trait.
 pub struct LazyLz4Writer<L, T, W>

--- a/martian-filetypes/src/lz4_file.rs
+++ b/martian-filetypes/src/lz4_file.rs
@@ -90,9 +90,7 @@
 //! }
 //! ```
 
-use crate::{
-    martian_filetype_inner, ErrorContext, FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite,
-};
+use crate::{martian_filetype_inner, ErrorContext, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
 use martian::{Error, MartianFileType};
 use serde::{Deserialize, Serialize};
 use std::convert::From;
@@ -119,8 +117,6 @@ where
         Self::from(source.as_ref())
     }
 }
-
-impl<F, T> FileStorage<T> for Lz4<F> where F: FileStorage<T> {}
 
 impl<F, T> FileTypeIO<T> for Lz4<F>
 where

--- a/martian-filetypes/src/macros.rs
+++ b/martian-filetypes/src/macros.rs
@@ -82,7 +82,7 @@ macro_rules! martian_filetype_decorator {
 macro_rules! martian_filetype_typed_decorator {
     ($(#[$attr:meta])* pub struct $name:ident, $extension:expr) => (
         $(#[$attr])*
-        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
         // The following attribute ensures that the struct will serialize into a
         // String like a PathBuf would.
         #[serde(transparent)]
@@ -94,6 +94,18 @@ macro_rules! martian_filetype_typed_decorator {
             #[serde(skip)]
             inner: ::std::marker::PhantomData<(T, F)>,
             path: ::std::path::PathBuf,
+        }
+
+        impl<F, T> Clone for $name<F, T>
+        where
+            F: MartianFileType,
+        {
+            fn clone(&self) -> Self {
+                Self {
+                    path: self.path.clone(),
+                    inner: Default::default(),
+                }
+            }
         }
 
         impl<F, T> ::martian::MartianFileType for $name<F, T>

--- a/martian-filetypes/src/macros.rs
+++ b/martian-filetypes/src/macros.rs
@@ -82,7 +82,7 @@ macro_rules! martian_filetype_decorator {
 macro_rules! martian_filetype_typed_decorator {
     ($(#[$attr:meta])* pub struct $name:ident, $extension:expr) => (
         $(#[$attr])*
-        #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+        #[derive(Serialize, Deserialize, PartialEq, Eq)]
         // The following attribute ensures that the struct will serialize into a
         // String like a PathBuf would.
         #[serde(transparent)]
@@ -105,6 +105,17 @@ macro_rules! martian_filetype_typed_decorator {
                     path: self.path.clone(),
                     inner: Default::default(),
                 }
+            }
+        }
+
+        impl<F, T> Debug for $name<F, T>
+        where
+            F: MartianFileType,
+        {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct(stringify!($name))
+                    .field("path", &self.path)
+                    .finish()
             }
         }
 

--- a/martian-filetypes/src/macros.rs
+++ b/martian-filetypes/src/macros.rs
@@ -1,6 +1,11 @@
+/// Create a type that wraps another implementation of MartianFileType.
+/// Internally stores path data, while delegating reading and writing to the
+/// implementation of the underlying type.
+/// This makes it easy to create non-type-specific wrappers that handle things
+/// like different compression formats.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! martian_filetype_inner {
+macro_rules! martian_filetype_decorator {
     ($(#[$attr:meta])* pub struct $name:ident, $extension:expr) => (
         $(#[$attr])*
         #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -56,6 +61,80 @@ macro_rules! martian_filetype_inner {
         }
 
         impl<F, P> From<P> for $name<F>
+        where
+            ::std::path::PathBuf: From<P>,
+            F: ::martian::MartianFileType,
+        {
+            fn from(source: P) -> Self {
+                let path_buf = ::std::path::PathBuf::from(source);
+                Self::from_path(path_buf.as_path())
+            }
+        }
+    )
+}
+
+/// Create a type that wraps another implementation of MartianFileType.
+/// Adds an explicit type annotation that can be used to associate a datatype
+/// with the wrapped file format.  This is sufficient for handling serialization
+/// formats with no additional type parameters.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! martian_filetype_typed_decorator {
+    ($(#[$attr:meta])* pub struct $name:ident, $extension:expr) => (
+        $(#[$attr])*
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        // The following attribute ensures that the struct will serialize into a
+        // String like a PathBuf would.
+        #[serde(transparent)]
+        pub struct $name<F, T>
+        where
+            F: ::martian::MartianFileType,
+        {
+            // Skip [de]serializing the inner
+            #[serde(skip)]
+            inner: ::std::marker::PhantomData<(T, F)>,
+            path: ::std::path::PathBuf,
+        }
+
+        impl<F, T> ::martian::MartianFileType for $name<F, T>
+        where
+            F: ::martian::MartianFileType,
+        {
+            fn extension() -> String {
+                $crate::maybe_add_format(F::extension(), $extension)
+            }
+
+            fn new(file_path: impl AsRef<std::path::Path>, file_name: impl AsRef<std::path::Path>) -> Self {
+                let path = ::martian::utils::make_path(file_path.as_ref(), file_name.as_ref(), Self::extension());
+                $name {
+                    inner: ::std::marker::PhantomData,
+                    path,
+                }
+            }
+        }
+
+        impl<F, T> AsRef<std::path::Path> for $name<F, T>
+        where
+            F: ::martian::MartianFileType
+        {
+            /// Coerces this MartianFileType to a Path slice.
+            fn as_ref(&self) -> &std::path::Path {
+                &self.path
+            }
+        }
+
+        impl<F, T> std::ops::Deref for $name<F, T>
+        where
+            F: ::martian::MartianFileType
+        {
+            type Target = ::std::path::Path;
+            /// Dereferences this MartianFileType to a Path slice.
+            fn deref(&self) -> &::std::path::Path {
+                &self.path
+            }
+        }
+
+        impl<F, T, P> From<P> for $name<F, T>
         where
             ::std::path::PathBuf: From<P>,
             F: ::martian::MartianFileType,

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -56,7 +56,7 @@ pub trait TableConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct DelimitedFormat<T, F, D>
 where
@@ -66,6 +66,19 @@ where
     path: PathBuf,
     #[serde(skip)]
     phantom: PhantomData<(T, F, D)>,
+}
+
+impl<T, F, D> Clone for DelimitedFormat<T, F, D>
+where
+    F: MartianFileType,
+    D: TableConfig,
+{
+    fn clone(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+            phantom: Default::default(),
+        }
+    }
 }
 
 impl<T, F, D> DelimitedFormat<T, F, D>

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -3,7 +3,7 @@
 //! items of type `T`.
 //!
 //! ## Simple read/write example
-//! `CsvFile` implements `FileTypeIO<T>` for any serializable type `T`.
+//! `CsvFile<T>` implements `FileTypeIO<Vec<T>>` for any serializable type `T`.
 //! ```rust
 //! use martian_filetypes::{FileTypeIO, tabular_file::CsvFile};
 //! use martian::Error;
@@ -27,7 +27,7 @@
 //!         std::fs::read_to_string(&csv_file)?,
 //!         "umis,reads\n10,15\n200,1005\n"
 //!     );
-//!     let decoded: Vec<BarcodeSummary> = csv_file.read()?;
+//!     let decoded = csv_file.read()?;
 //!     assert_eq!(summary, decoded);
 //!     # std::fs::remove_file(csv_file)?; // Remove the file (hidden from the doc)
 //!     Ok(())
@@ -159,9 +159,7 @@ table_config! { TabDelimiterNoHeader, b'\t', "tsv", false }
 pub type TsvFormatNoHeader<T, F> = DelimitedFormat<T, F, TabDelimiterNoHeader>;
 pub type TsvFileNoHeader<T> = TsvFormatNoHeader<T, Tsv>;
 
-/// Any type `T` that can be deserialized implements `read()` from a `JsonFile`
-/// Any type `T` that can be serialized can be saved as a `JsonFile`.
-/// The saved JsonFile will be pretty formatted using 4 space indentation.
+/// Enable writing and reading a vector of T from a tabular file.
 impl<F, D, T> FileTypeIO<Vec<T>> for DelimitedFormat<T, F, D>
 where
     T: Serialize + DeserializeOwned,
@@ -377,18 +375,18 @@ mod tests {
 
     #[test]
     fn test_round_trip() -> Result<(), Error> {
-        assert!(crate::round_trip_check::<CsvFile<Cell>, _>(&cells())?);
-        assert!(crate::round_trip_check::<TsvFile<Cell>, _>(&cells())?);
+        assert!(crate::round_trip_check::<CsvFile<_>, _>(&cells())?);
+        assert!(crate::round_trip_check::<TsvFile<_>, _>(&cells())?);
         Ok(())
     }
 
     #[test]
     fn test_lazy_round_trip() -> Result<(), Error> {
-        assert!(crate::lazy_round_trip_check::<CsvFile<Cell>, _>(
+        assert!(crate::lazy_round_trip_check::<CsvFile<_>, _>(
             &cells(),
             true
         )?);
-        assert!(crate::lazy_round_trip_check::<TsvFile<Cell>, _>(
+        assert!(crate::lazy_round_trip_check::<TsvFile<_>, _>(
             &cells(),
             true
         )?);

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -404,8 +404,8 @@ mod tests {
     #[test]
     fn test_lazy_header_only() -> Result<(), Error> {
         let dir = tempfile::tempdir()?;
-        let cells_tsv = TsvFile::new(dir.path(), "test");
-        let mut writer: LazyTabularWriter<_, _, Cell, _> = cells_tsv.lazy_writer()?;
+        let cells_tsv: TsvFile<Cell> = TsvFile::new(dir.path(), "test");
+        let mut writer = cells_tsv.lazy_writer()?;
         writer.write_header()?;
         writer.finish()?;
         assert_eq!(std::fs::read_to_string(&cells_tsv)?, "barcode\tgenome\n");
@@ -415,8 +415,8 @@ mod tests {
     #[test]
     fn test_lazy_no_header() -> Result<(), Error> {
         let dir = tempfile::tempdir()?;
-        let cells_tsv = TsvFile::new(dir.path(), "test");
-        let writer: LazyTabularWriter<_, _, Cell, _> = cells_tsv.lazy_writer()?;
+        let cells_tsv: TsvFile<Cell> = TsvFile::new(dir.path(), "test");
+        let writer = cells_tsv.lazy_writer()?;
         writer.finish()?;
         assert_eq!(std::fs::read_to_string(&cells_tsv)?, "");
         Ok(())

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -148,7 +148,7 @@ where
 #[macro_export]
 macro_rules! table_config {
     ($name:ident, $delim:expr, $format: expr, $header: expr, $comment:expr) => {
-        #[derive(Clone, Copy)]
+        #[derive(Debug, Clone, Copy)]
         pub struct $name;
         impl TableConfig for $name {
             fn delimiter() -> u8 {

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -5,7 +5,7 @@
 //! ## Simple read/write example
 //! `CsvFile<T>` implements `FileTypeIO<Vec<T>>` for any serializable type `T`.
 //! ```rust
-//! use martian_filetypes::{FileTypeIO, tabular_file::CsvFile};
+//! use martian_filetypes::{FileTypeRead, FileTypeWrite, tabular_file::CsvFile};
 //! use martian::Error;
 //! use serde::{Serialize, Deserialize};
 //!
@@ -34,7 +34,7 @@
 //! }
 //! ```
 
-use crate::{FileTypeIO, LazyAgents, LazyRead, LazyWrite};
+use crate::{FileTypeRead, FileTypeWrite, LazyAgents, LazyRead, LazyWrite};
 use anyhow::format_err;
 use martian::{Error, MartianFileType};
 use martian_derive::martian_filetype;
@@ -191,9 +191,9 @@ pub type TsvFormatNoHeader<T, F> = DelimitedFormat<T, F, TabDelimiterNoHeader>;
 pub type TsvFileNoHeader<T> = TsvFormatNoHeader<T, Tsv>;
 
 /// Enable writing and reading a vector of T from a tabular file.
-impl<F, D, T> FileTypeIO<Vec<T>> for DelimitedFormat<T, F, D>
+impl<F, D, T> FileTypeRead<Vec<T>> for DelimitedFormat<T, F, D>
 where
-    T: Serialize + DeserializeOwned,
+    T: DeserializeOwned,
     F: MartianFileType,
     D: TableConfig,
 {
@@ -203,7 +203,15 @@ where
         let rows = iter.collect::<csv::Result<Vec<T>>>()?;
         Ok(rows)
     }
+}
 
+/// Enable writing and reading a vector of T from a tabular file.
+impl<F, D, T> FileTypeWrite<Vec<T>> for DelimitedFormat<T, F, D>
+where
+    T: Serialize,
+    F: MartianFileType,
+    D: TableConfig,
+{
     fn write_into<W: Write>(writer: W, item: &Vec<T>) -> Result<(), Error> {
         let mut wtr = csv::WriterBuilder::default()
             .delimiter(D::delimiter())

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -58,7 +58,7 @@ pub trait TableConfig {
 pub struct DelimitedFormat<T, F, D>
 where
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
 {
     path: PathBuf,
     #[serde(skip)]
@@ -68,7 +68,7 @@ where
 impl<T, F, D> MartianFileType for DelimitedFormat<T, F, D>
 where
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
 {
     fn extension() -> String {
         crate::maybe_add_format(F::extension(), D::format())
@@ -87,7 +87,7 @@ where
 impl<T, F, D> AsRef<Path> for DelimitedFormat<T, F, D>
 where
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
 {
     fn as_ref(&self) -> &Path {
         &self.path
@@ -97,7 +97,7 @@ where
 impl<T, F, D> std::ops::Deref for DelimitedFormat<T, F, D>
 where
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
 {
     type Target = Path;
     /// Dereferences this DelimitedFormat to a Path slice.
@@ -110,7 +110,7 @@ impl<T, F, D, P> From<P> for DelimitedFormat<T, F, D>
 where
     PathBuf: From<P>,
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
 {
     fn from(source: P) -> Self {
         let path_buf = PathBuf::from(source);
@@ -120,7 +120,7 @@ where
 
 macro_rules! table_config {
     ($name:ident, $delim:expr, $format: expr, $header: expr) => {
-        #[derive(Debug, Clone, Copy)]
+        #[derive(Clone, Copy)]
         pub struct $name;
         impl TableConfig for $name {
             fn delimiter() -> u8 {
@@ -163,8 +163,8 @@ pub type TsvFileNoHeader<T> = TsvFormatNoHeader<T, Tsv>;
 impl<F, D, T> FileTypeIO<Vec<T>> for DelimitedFormat<T, F, D>
 where
     T: Serialize + DeserializeOwned,
-    F: MartianFileType + Debug,
-    D: TableConfig + Debug,
+    F: MartianFileType,
+    D: TableConfig,
 {
     fn read_from<R: Read>(reader: R) -> Result<Vec<T>, Error> {
         let mut rdr = csv::ReaderBuilder::new()
@@ -193,7 +193,7 @@ where
 pub struct LazyTabularReader<F, D, T, R>
 where
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
     R: Read,
     T: DeserializeOwned,
 {
@@ -204,7 +204,7 @@ where
 impl<F, D, T, R> Iterator for LazyTabularReader<F, D, T, R>
 where
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
     R: Read,
     T: DeserializeOwned,
 {
@@ -221,7 +221,7 @@ where
 impl<F, D, T, R> LazyRead<T, R> for LazyTabularReader<F, D, T, R>
 where
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
     R: Read,
     T: DeserializeOwned,
 {
@@ -242,7 +242,7 @@ pub struct LazyTabularWriter<F, D, T, W>
 where
     F: MartianFileType,
     W: Write,
-    D: TableConfig + Debug,
+    D: TableConfig,
 {
     writer: csv::Writer<W>,
     phantom: PhantomData<(F, D, T)>,
@@ -275,7 +275,7 @@ impl<F, D, T, W> LazyTabularWriter<F, D, T, W>
 where
     F: MartianFileType,
     W: Write,
-    D: TableConfig + Debug,
+    D: TableConfig,
     T: Serialize + Default,
 {
     pub fn write_header(&mut self) -> Result<(), Error> {
@@ -289,7 +289,7 @@ impl<F, D, T, W> LazyWrite<T, W> for LazyTabularWriter<F, D, T, W>
 where
     F: MartianFileType,
     W: Write,
-    D: TableConfig + Debug,
+    D: TableConfig,
     T: Serialize,
 {
     type FileType = DelimitedFormat<T, F, D>;
@@ -316,7 +316,7 @@ where
 impl<F, D, T, W, R> LazyAgents<T, W, R> for DelimitedFormat<T, F, D>
 where
     F: MartianFileType,
-    D: TableConfig + Debug,
+    D: TableConfig,
     T: Serialize + DeserializeOwned,
     W: Write,
     R: Read,

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -399,6 +399,23 @@ mod tests {
             std::fs::read_to_string(&cells_tsv)?,
             "barcode\tgenome\nACGT\thg19\nTCAT\tmm10\n"
         );
+        assert_eq!(
+            cells_tsv.read_headers()?,
+            Some(vec!["barcode".to_string(), "genome".to_string()])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_tsv_write_no_header() -> Result<(), Error> {
+        let dir = tempfile::tempdir()?;
+        let cells_tsv = TsvFileNoHeader::new(dir.path(), "test");
+        cells_tsv.write(&cells())?;
+        assert_eq!(
+            std::fs::read_to_string(&cells_tsv)?,
+            "ACGT\thg19\nTCAT\tmm10\n"
+        );
+        assert!(cells_tsv.read_headers()?.is_none());
         Ok(())
     }
 

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -56,7 +56,7 @@ pub trait TableConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct DelimitedFormat<T, F, D>
 where
@@ -78,6 +78,19 @@ where
             path: self.path.clone(),
             phantom: Default::default(),
         }
+    }
+}
+
+impl<T, F, D> Debug for DelimitedFormat<T, F, D>
+where
+    F: MartianFileType,
+    D: TableConfig,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DelimitedFormat")
+            .field("path", &self.path)
+            .field("table_config", &std::any::type_name::<D>())
+            .finish()
     }
 }
 

--- a/martian-filetypes/src/zstd_file.rs
+++ b/martian-filetypes/src/zstd_file.rs
@@ -90,9 +90,7 @@
 //! }
 //! ```
 
-use crate::{
-    martian_filetype_inner, ErrorContext, FileStorage, FileTypeIO, LazyAgents, LazyRead, LazyWrite,
-};
+use crate::{martian_filetype_inner, ErrorContext, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
 use martian::{Error, MartianFileType};
 use serde::{Deserialize, Serialize};
 use std::convert::From;
@@ -119,8 +117,6 @@ where
         Self::from(source.as_ref())
     }
 }
-
-impl<F, T> FileStorage<T> for Zstd<F> where F: FileStorage<T> {}
 
 impl<F, T> FileTypeIO<T> for Zstd<F>
 where

--- a/martian-filetypes/src/zstd_file.rs
+++ b/martian-filetypes/src/zstd_file.rs
@@ -30,7 +30,7 @@
 //!     # std::fs::remove_file(zstd_json_file)?; // Remove the file (hidden from the doc)
 //!
 //!     // --------------------- Bincode ----------------------------------
-//!     let zstd_bin_file: Zstd<BincodeFile> = Zstd::from("example"); // example.bincode.zst
+//!     let zstd_bin_file: Zstd<BincodeFile<_>> = Zstd::from("example"); // example.bincode.zst
 //!     // Need to explcitly annotate the type id you are using from() or MartianFileType::new()
 //!     zstd_bin_file.write(&chem)?; // Writes zstd compressed bincode file
 //!     let decoded: Chemistry = zstd_bin_file.read()?;
@@ -57,7 +57,7 @@
 //! use serde::{Serialize, Deserialize};
 //!
 //! fn main() -> Result<(), Error> {
-//!     let zstd_bin_file: Zstd<BincodeFile> = Zstd::from("example_lazy");
+//!     let zstd_bin_file: Zstd<BincodeFile<_>> = Zstd::from("example_lazy");
 //!     let mut zstd_writer = zstd_bin_file.lazy_writer()?;
 //!     // The type of the zstd_writer will be inferred by the compiler as:
 //!     // LazyZstdWriter<LazyBincodeWriter<i32, zstd::encoder::Encoder<BufWriter<File>>>, i32, BufWriter<File>>
@@ -90,14 +90,16 @@
 //! }
 //! ```
 
-use crate::{martian_filetype_inner, ErrorContext, FileTypeIO, LazyAgents, LazyRead, LazyWrite};
+use crate::{
+    martian_filetype_decorator, ErrorContext, FileTypeIO, LazyAgents, LazyRead, LazyWrite,
+};
 use martian::{Error, MartianFileType};
 use serde::{Deserialize, Serialize};
 use std::convert::From;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::marker::PhantomData;
 
-martian_filetype_inner! {
+martian_filetype_decorator! {
     /// A struct that wraps a basic `MartianFileType` and adds zstd compression
     /// capability.
     pub struct Zstd, "zst"
@@ -110,7 +112,7 @@ where
     /// Create an Zstd wrapped filetype from a basic filetype
     /// ```rust
     /// use martian_filetypes::{zstd_file::Zstd, bin_file::BincodeFile};
-    /// let zstd_bin_file = Zstd::from_filetype(BincodeFile::from("example"));
+    /// let zstd_bin_file = Zstd::from_filetype(BincodeFile::<()>::from("example"));
     /// assert_eq!(zstd_bin_file.as_ref(), std::path::Path::new("example.bincode.zst"));
     /// ```
     pub fn from_filetype(source: F) -> Self {
@@ -273,7 +275,7 @@ mod tests {
     #[test]
     fn test_zstd_new() {
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file"),
+            Zstd::<JsonFile<()>>::new("/some/path/", "file"),
             Zstd {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.zst")
@@ -281,7 +283,7 @@ mod tests {
         );
 
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file.json"),
+            Zstd::<JsonFile<()>>::new("/some/path/", "file.json"),
             Zstd {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.zst")
@@ -289,7 +291,7 @@ mod tests {
         );
 
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file_json"),
+            Zstd::<JsonFile<()>>::new("/some/path/", "file_json"),
             Zstd {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file_json.json.zst")
@@ -297,7 +299,7 @@ mod tests {
         );
 
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file.json.zst"),
+            Zstd::<JsonFile<()>>::new("/some/path/", "file.json.zst"),
             Zstd {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.json.zst")
@@ -305,7 +307,7 @@ mod tests {
         );
 
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file.tmp"),
+            Zstd::<JsonFile<()>>::new("/some/path/", "file.tmp"),
             Zstd {
                 inner: PhantomData,
                 path: PathBuf::from("/some/path/file.tmp.json.zst")
@@ -313,7 +315,7 @@ mod tests {
         );
 
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file").as_ref(),
+            Zstd::<JsonFile<()>>::new("/some/path/", "file").as_ref(),
             Path::new("/some/path/file.json.zst")
         );
     }
@@ -342,42 +344,42 @@ mod tests {
     #[test]
     fn test_zstd_from() {
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file"),
-            Zstd::<JsonFile>::from("/some/path/file")
+            Zstd::<JsonFile<()>>::new("/some/path/", "file"),
+            Zstd::<JsonFile<()>>::from("/some/path/file")
         );
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file"),
-            Zstd::<JsonFile>::from("/some/path/file.json")
+            Zstd::<JsonFile<()>>::new("/some/path/", "file"),
+            Zstd::<JsonFile<()>>::from("/some/path/file.json")
         );
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file"),
-            Zstd::<JsonFile>::from("/some/path/file.json.zst")
+            Zstd::<JsonFile<()>>::new("/some/path/", "file"),
+            Zstd::<JsonFile<()>>::from("/some/path/file.json.zst")
         );
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file.tmp"),
-            Zstd::<JsonFile>::from("/some/path/file.tmp.json.zst")
+            Zstd::<JsonFile<()>>::new("/some/path/", "file.tmp"),
+            Zstd::<JsonFile<()>>::from("/some/path/file.tmp.json.zst")
         );
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file.tmp"),
-            Zstd::<JsonFile>::from("/some/path/file.tmp")
+            Zstd::<JsonFile<()>>::new("/some/path/", "file.tmp"),
+            Zstd::<JsonFile<()>>::from("/some/path/file.tmp")
         );
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file.tmp.json"),
-            Zstd::<JsonFile>::from("/some/path/file.tmp")
+            Zstd::<JsonFile<()>>::new("/some/path/", "file.tmp.json"),
+            Zstd::<JsonFile<()>>::from("/some/path/file.tmp")
         );
     }
 
     #[test]
     fn test_zstd_from_filetype() {
         assert_eq!(
-            Zstd::<JsonFile>::new("/some/path/", "file"),
+            Zstd::<JsonFile<()>>::new("/some/path/", "file"),
             Zstd::from_filetype(JsonFile::new("/some/path/", "file"))
         );
     }
 
     #[test]
     fn test_zstd_extension() {
-        assert_eq!(Zstd::<JsonFile>::extension(), "json.zst");
+        assert_eq!(Zstd::<JsonFile<()>>::extension(), "json.zst");
     }
 
     #[test]
@@ -401,7 +403,7 @@ mod tests {
     #[test]
     fn test_json_zstd_lazy_write_no_finish() {
         let dir = tempfile::tempdir().unwrap();
-        let file = Zstd::<JsonFile>::new(dir.path(), "file");
+        let file = Zstd::<JsonFile<Vec<usize>>>::new(dir.path(), "file");
         let mut writer = file.lazy_writer().unwrap();
         for i in 0..10 {
             writer.write_item(&i).unwrap();
@@ -416,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_serialize() {
-        let zstd_file = Zstd::<JsonFile>::new("/some/path/", "file");
+        let zstd_file = Zstd::<JsonFile<Vec<usize>>>::new("/some/path/", "file");
         let path = PathBuf::from("/some/path/file.json.zst");
         assert_eq!(
             serde_json::to_string(&zstd_file).unwrap(),
@@ -426,8 +428,8 @@ mod tests {
 
     #[test]
     fn test_deserialize() {
-        let zstd_file: Zstd<JsonFile> =
+        let zstd_file: Zstd<JsonFile<()>> =
             serde_json::from_str(r#""/some/path/file.json.zst""#).unwrap();
-        assert_eq!(zstd_file, Zstd::<JsonFile>::new("/some/path/", "file"));
+        assert_eq!(zstd_file, Zstd::<JsonFile<()>>::new("/some/path/", "file"));
     }
 }

--- a/martian-filetypes/tests/ui/invalid_type_read.rs
+++ b/martian-filetypes/tests/ui/invalid_type_read.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use martian_derive::martian_filetype;
 use martian_filetypes::bin_file::BinaryFormat;
 use martian_filetypes::json_file::JsonFormat;
-use martian_filetypes::{FileStorage, FileTypeIO};
+use martian_filetypes::FileTypeIO;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,21 +16,20 @@ struct Creature {
 }
 
 martian_filetype! {FeatureFile, "feat"}
-impl FileStorage<Feature> for FeatureFile {}
 
 fn main() -> Result<(), Error> {
     let feature = Feature { id: 5 };
     let creature = Creature { id: 10 };
     // Json Format
     {
-        let feat_file: JsonFormat<FeatureFile> = JsonFormat::from("feature");
+        let feat_file: JsonFormat<FeatureFile, Feature> = JsonFormat::from("feature");
         feat_file.write(&feature)?;
         let new_feature: Creature = feat_file.read()?; // Compiler error
         std::fs::remove_file(feat_file)?;
     }
     // Binary Format
     {
-        let feat_file: BinaryFormat<FeatureFile> = BinaryFormat::from("feature");
+        let feat_file: BinaryFormat<FeatureFile, Feature> = BinaryFormat::from("feature");
         feat_file.write(&feature)?;
         let new_feature: Creature = feat_file.read()?; // Compiler error
         std::fs::remove_file(feat_file)?;

--- a/martian-filetypes/tests/ui/invalid_type_read.rs
+++ b/martian-filetypes/tests/ui/invalid_type_read.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use martian_derive::martian_filetype;
 use martian_filetypes::bin_file::BinaryFormat;
 use martian_filetypes::json_file::JsonFormat;
-use martian_filetypes::FileTypeIO;
+use martian_filetypes::{FileTypeRead, FileTypeWrite};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/martian-filetypes/tests/ui/invalid_type_read.stderr
+++ b/martian-filetypes/tests/ui/invalid_type_read.stderr
@@ -1,15 +1,15 @@
 error[E0308]: `?` operator has incompatible types
-  --> $DIR/invalid_type_read.rs:28:37
+  --> tests/ui/invalid_type_read.rs:27:37
    |
-28 |         let new_feature: Creature = feat_file.read()?; // Compiler error
+27 |         let new_feature: Creature = feat_file.read()?; // Compiler error
    |                                     ^^^^^^^^^^^^^^^^^ expected struct `Creature`, found struct `Feature`
    |
    = note: `?` operator cannot convert from `Feature` to `Creature`
 
 error[E0308]: `?` operator has incompatible types
-  --> $DIR/invalid_type_read.rs:35:37
+  --> tests/ui/invalid_type_read.rs:34:37
    |
-35 |         let new_feature: Creature = feat_file.read()?; // Compiler error
+34 |         let new_feature: Creature = feat_file.read()?; // Compiler error
    |                                     ^^^^^^^^^^^^^^^^^ expected struct `Creature`, found struct `Feature`
    |
    = note: `?` operator cannot convert from `Feature` to `Creature`

--- a/martian-filetypes/tests/ui/invalid_type_write.rs
+++ b/martian-filetypes/tests/ui/invalid_type_write.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use martian_derive::martian_filetype;
 use martian_filetypes::bin_file::BinaryFormat;
 use martian_filetypes::json_file::JsonFormat;
-use martian_filetypes::{FileStorage, FileTypeIO};
+use martian_filetypes::FileTypeIO;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,19 +16,18 @@ struct Creature {
 }
 
 martian_filetype! {FeatureFile, "feat"}
-impl FileStorage<Feature> for FeatureFile {}
 
 fn main() -> Result<(), Error> {
     let creature = Creature { id: 10 };
 
     // Json format
     {
-        let feat_file: JsonFormat<FeatureFile> = JsonFormat::from("feature");
+        let feat_file: JsonFormat<FeatureFile, Feature> = JsonFormat::from("feature");
         feat_file.write(&creature)?; // This is a compiler error
     }
     // Binary format
     {
-        let feat_file: BinaryFormat<FeatureFile> = BinaryFormat::from("feature");
+        let feat_file: BinaryFormat<FeatureFile, Feature> = BinaryFormat::from("feature");
         feat_file.write(&creature)?; // This is a compiler error
     }
 

--- a/martian-filetypes/tests/ui/invalid_type_write.rs
+++ b/martian-filetypes/tests/ui/invalid_type_write.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use martian_derive::martian_filetype;
 use martian_filetypes::bin_file::BinaryFormat;
 use martian_filetypes::json_file::JsonFormat;
-use martian_filetypes::FileTypeIO;
+use martian_filetypes::FileTypeWrite;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/martian-filetypes/tests/ui/invalid_type_write.stderr
+++ b/martian-filetypes/tests/ui/invalid_type_write.stderr
@@ -1,31 +1,31 @@
 error[E0308]: mismatched types
-   --> tests/ui/invalid_type_write.rs:27:25
-    |
-27  |         feat_file.write(&creature)?; // This is a compiler error
-    |                   ----- ^^^^^^^^^ expected struct `Feature`, found struct `Creature`
-    |                   |
-    |                   arguments to this function are incorrect
-    |
-    = note: expected reference `&Feature`
-               found reference `&Creature`
+  --> tests/ui/invalid_type_write.rs:26:25
+   |
+26 |         feat_file.write(&creature)?; // This is a compiler error
+   |                   ----- ^^^^^^^^^ expected struct `Feature`, found struct `Creature`
+   |                   |
+   |                   arguments to this function are incorrect
+   |
+   = note: expected reference `&Feature`
+              found reference `&Creature`
 note: associated function defined here
-   --> src/lib.rs
-    |
-    |     fn write(&self, item: &T) -> Result<(), Error> {
-    |        ^^^^^
+  --> src/lib.rs
+   |
+   |     fn write(&self, item: &T) -> Result<(), Error> {
+   |        ^^^^^
 
 error[E0308]: mismatched types
-   --> tests/ui/invalid_type_write.rs:32:25
-    |
-32  |         feat_file.write(&creature)?; // This is a compiler error
-    |                   ----- ^^^^^^^^^ expected struct `Feature`, found struct `Creature`
-    |                   |
-    |                   arguments to this function are incorrect
-    |
-    = note: expected reference `&Feature`
-               found reference `&Creature`
+  --> tests/ui/invalid_type_write.rs:31:25
+   |
+31 |         feat_file.write(&creature)?; // This is a compiler error
+   |                   ----- ^^^^^^^^^ expected struct `Feature`, found struct `Creature`
+   |                   |
+   |                   arguments to this function are incorrect
+   |
+   = note: expected reference `&Feature`
+              found reference `&Creature`
 note: associated function defined here
-   --> src/lib.rs
-    |
-    |     fn write(&self, item: &T) -> Result<(), Error> {
-    |        ^^^^^
+  --> src/lib.rs
+   |
+   |     fn write(&self, item: &T) -> Result<(), Error> {
+   |        ^^^^^

--- a/martian/src/utils.rs
+++ b/martian/src/utils.rs
@@ -97,8 +97,7 @@ fn _set_extension(mut result: PathBuf, extension: String) -> PathBuf {
             *r_str.last().expect("Path must be non-empty.")
         },
         std::path::MAIN_SEPARATOR as u8,
-        "You passed a directory instead of a file: {:?}",
-        result
+        "You passed a directory instead of a file: {result:?}",
     );
 
     assert!(!extension.starts_with('.'));


### PR DESCRIPTION
Forces file types themselves to declare an explicit `T`, rather than inferring it indirectly through `read` and `write` calls.  This has the added advantage of making it a compile-time error to get a lazy reader or writer over a file that doesn't contain a `Vec<T>`.