### PR TITLE
Remove martian::Json

### DIFF
--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -14,7 +14,6 @@ use std::time::SystemTime;
 use time::{OffsetDateTime, UtcOffset};
 
 pub type JsonDict = Map<String, Value>;
-pub type Json = Value;
 type Result<T> = std::result::Result<T, Error>;
 
 const METADATA_PREFIX: &str = "_";


### PR DESCRIPTION
Remove `martian::Json`, because it's unused and easily confused with `martian_filetypes::json_file::Json`.

Related PR
- https://github.com/10XDev/cellranger/pull/11961
