### PR TITLE
Implement a helper trait for creating temporary martian files.

### DIFF
--- a/martian-filetypes/benches/benchmarks.rs
+++ b/martian-filetypes/benches/benchmarks.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use martian::{MartianFileType, MartianTempFile};
+use martian::MartianTempFile;
 use martian_filetypes::bin_file::BincodeFile;
 use martian_filetypes::json_file::JsonFile;
 use martian_filetypes::lz4_file::Lz4;

--- a/martian-filetypes/benches/benchmarks.rs
+++ b/martian-filetypes/benches/benchmarks.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use martian::MartianFileType;
+use martian::{MartianFileType, MartianTempFile};
 use martian_filetypes::bin_file::BincodeFile;
 use martian_filetypes::json_file::JsonFile;
 use martian_filetypes::lz4_file::Lz4;
@@ -16,14 +16,13 @@ struct Foo {
 
 fn lazy_read_bench<F, T>(c: &mut Criterion, data: Vec<T>, key: &'static str)
 where
-    F: FileTypeIO<Vec<T>> + LazyFileTypeIO<T> + 'static,
+    F: FileTypeIO<Vec<T>> + LazyFileTypeIO<T> + MartianTempFile + 'static,
     Lz4<F>: FileTypeIO<Vec<T>> + LazyFileTypeIO<T>,
 {
-    let dir = tempfile::tempdir().unwrap();
-    let file_full = F::new(dir.path(), "benchmark_full");
-    let file_lazy = F::new(dir.path(), "benchmark_lazy");
-    let file_lz4 = Lz4::<F>::new(dir.path(), "benchmark_lz4");
-    let file_lz4_lazy = Lz4::<F>::new(dir.path(), "benchmark_lz4_lazy");
+    let file_full = F::tempfile().unwrap();
+    let file_lazy = F::tempfile().unwrap();
+    let file_lz4 = Lz4::<F>::tempfile().unwrap();
+    let file_lz4_lazy = Lz4::<F>::tempfile().unwrap();
     file_full.write(&data).unwrap();
     file_lazy.write(&data).unwrap();
     file_lz4.write(&data).unwrap();
@@ -65,11 +64,10 @@ where
     Lz4<F>: FileTypeIO<Vec<T>> + LazyFileTypeIO<T>,
     T: Clone + 'static,
 {
-    let dir = tempfile::tempdir().unwrap();
-    let file_full = F::new(dir.path(), "benchmark_full");
-    let file_lazy = F::new(dir.path(), "benchmark_lazy");
-    let file_lz4 = Lz4::<F>::new(dir.path(), "benchmark_lz4");
-    let file_lz4_lazy = Lz4::<F>::new(dir.path(), "benchmark_lz4_lazy");
+    let file_full = F::tempfile().unwrap();
+    let file_lazy = F::tempfile().unwrap();
+    let file_lz4 = Lz4::<F>::tempfile().unwrap();
+    let file_lz4_lazy = Lz4::<F>::tempfile().unwrap();
     let elements = data.len() as u32;
 
     let mut group = c.benchmark_group(key);

--- a/martian-filetypes/src/gzip_file.rs
+++ b/martian-filetypes/src/gzip_file.rs
@@ -20,8 +20,7 @@
 //!
 //! fn main() -> Result<(), Error> {
 //!     let chem = Chemistry { name: "SCVDJ".into(), paired_end: true };
-//!     let gz_json_file = Gzip::from_filetype(JsonFile::from("example")); // example.json.gz
-//!     // gz_json_file has the type Gzip<JsonFile>
+//!     let gz_json_file: Gzip<JsonFile<_>> = "example".into(); // example.json.gz
 //!     gz_json_file.write(&chem)?; // Writes gzip compressed json file
 //!     let decoded: Chemistry = gz_json_file.read()?;
 //!     assert_eq!(chem, decoded);

--- a/martian-filetypes/src/gzip_file.rs
+++ b/martian-filetypes/src/gzip_file.rs
@@ -46,21 +46,6 @@ crate::martian_filetype_decorator! {
     pub struct Gzip, "gz"
 }
 
-impl<F> Gzip<F>
-where
-    F: MartianFileType,
-{
-    /// Create an Gzip wrapped filetype from a basic filetype
-    /// ```rust
-    /// use martian_filetypes::{gzip_file::Gzip, bin_file::BincodeFile};
-    /// let gz_bin_file = Gzip::from_filetype(BincodeFile::<()>::from("example"));
-    /// assert_eq!(gz_bin_file.as_ref(), std::path::Path::new("example.bincode.gz"));
-    /// ```
-    pub fn from_filetype(source: F) -> Self {
-        Self::from(source.as_ref())
-    }
-}
-
 impl<F, T> FileTypeRead<T> for Gzip<F>
 where
     F: MartianFileType + FileTypeIO<T>,
@@ -206,6 +191,7 @@ mod tests {
     use super::*;
     use crate::json_file::JsonFile;
     use crate::LazyFileTypeIO;
+    use martian::MartianTempFile;
     use std::path::{Path, PathBuf};
 
     martian_derive::martian_filetype! {CompoundFile, "foo.bar"}
@@ -308,23 +294,13 @@ mod tests {
     }
 
     #[test]
-    fn test_gz_from_filetype() {
-        assert_eq!(
-            Gzip::<JsonFile<()>>::new("/some/path/", "file"),
-            Gzip::from_filetype(JsonFile::new("/some/path/", "file"))
-        );
-    }
-
-    #[test]
     fn test_gz_extension() {
         assert_eq!(Gzip::<JsonFile<()>>::extension(), "json.gz");
     }
 
     #[test]
     fn test_json_gz_lazy_write() -> Result<(), Error> {
-        let dir = tempfile::tempdir()?;
-        let json_file = JsonFile::new(dir.path(), "file");
-        let file = Gzip::from_filetype(json_file);
+        let file = Gzip::<JsonFile<_>>::tempfile()?;
         let mut writer = file.lazy_writer()?;
         for i in 0..10usize {
             writer.write_item(&i)?;
@@ -339,19 +315,19 @@ mod tests {
     }
 
     #[test]
-    fn test_json_gz_lazy_write_no_finish() {
-        let dir = tempfile::tempdir().unwrap();
-        let file: Gzip<JsonFile<_>> = Gzip::new(dir.path(), "file");
-        let mut writer = file.lazy_writer().unwrap();
+    fn test_json_gz_lazy_write_no_finish() -> Result<(), Error> {
+        let file = Gzip::<JsonFile<_>>::tempfile()?;
+        let mut writer = file.lazy_writer()?;
         for i in 0..10 {
-            writer.write_item(&i).unwrap();
+            writer.write_item(&i)?;
         }
         drop(writer);
-        let reader = file.lazy_reader().unwrap();
+        let reader = file.lazy_reader()?;
         for (i, val) in reader.enumerate() {
-            let val: usize = val.unwrap();
+            let val: usize = val?;
             assert_eq!(val, i);
         }
+        Ok(())
     }
 
     #[test]

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -319,6 +319,9 @@ pub(crate) fn maybe_add_format(extension: String, format: &str) -> String {
 }
 
 #[cfg(test)]
+use martian::MartianTempFile;
+
+#[cfg(test)]
 pub fn round_trip_check<F, T>(input: &T) -> Result<bool, Error>
 where
     F: FileTypeIO<T>,
@@ -326,8 +329,7 @@ where
 {
     // TEST 1: Write as F and read from F
     let pass_direct = {
-        let dir = tempfile::tempdir()?;
-        let file = F::new(dir.path(), "my_file_roundtrip");
+        let file = F::tempfile()?;
         file.write(input)?;
         let decoded: T = file.read()?;
         input == &decoded
@@ -335,8 +337,7 @@ where
 
     // TEST 2: Write as Lz4<F> and read from Lz4<F>
     let pass_compressed_lz4 = {
-        let dir = tempfile::tempdir()?;
-        let file = lz4_file::Lz4::<F>::new(dir.path(), "my_file_roundtrip_compressed");
+        let file = lz4_file::Lz4::<F>::tempfile()?;
         file.write(input)?;
         let decoded: T = file.read()?;
         input == &decoded
@@ -344,8 +345,7 @@ where
 
     // TEST 3: Write as Gzip<F> and read from Gzip<F>
     let pass_compressed_gzip = {
-        let dir = tempfile::tempdir()?;
-        let file = gzip_file::Gzip::<F>::new(dir.path(), "my_file_roundtrip_compressed");
+        let file = gzip_file::Gzip::<F>::tempfile()?;
         file.write(input)?;
         let decoded: T = file.read()?;
         input == &decoded
@@ -363,8 +363,7 @@ where
 {
     // Write + Lazy read
     let pass_w_lr = {
-        let dir = tempfile::tempdir()?;
-        let file = F::new(dir.path(), "my_file");
+        let file = F::tempfile()?;
         file.write(input)?;
         let decoded: Vec<T> = file.read_all()?;
         input == &decoded
@@ -372,8 +371,7 @@ where
 
     // Write + Lazy read [Compressed]
     let pass_w_lr_c = {
-        let dir = tempfile::tempdir()?;
-        let file = lz4_file::Lz4::<F>::new(dir.path(), "my_file");
+        let file = lz4_file::Lz4::<F>::tempfile()?;
         file.write(input)?;
         let decoded: Vec<T> = file.read_all()?;
         input == &decoded
@@ -381,8 +379,7 @@ where
 
     // Lazy write + read
     let pass_lw_r = if require_read {
-        let dir = tempfile::tempdir()?;
-        let file = F::new(dir.path(), "my_file");
+        let file = F::tempfile()?;
         let mut lazy_writer = file.lazy_writer()?;
         for item in input {
             lazy_writer.write_item(item)?;
@@ -396,8 +393,7 @@ where
 
     // Lazy write + read [Compressed]
     let pass_lw_r_c = if require_read {
-        let dir = tempfile::tempdir()?;
-        let file = lz4_file::Lz4::<F>::new(dir.path(), "my_file");
+        let file = lz4_file::Lz4::<F>::tempfile()?;
         let mut lazy_writer = file.lazy_writer()?;
         for item in input {
             lazy_writer.write_item(item)?;
@@ -411,8 +407,7 @@ where
 
     // Lazy write + Lazy read
     let pass_lw_lr = {
-        let dir = tempfile::tempdir()?;
-        let file = F::new(dir.path(), "my_file");
+        let file = F::tempfile()?;
         let mut lazy_writer = file.lazy_writer()?;
         for item in input {
             lazy_writer.write_item(item)?;
@@ -424,8 +419,7 @@ where
 
     // Lazy write + Lazy read [Compressed]
     let pass_lw_lr_c = {
-        let dir = tempfile::tempdir()?;
-        let file = lz4_file::Lz4::<F>::new(dir.path(), "my_file");
+        let file = lz4_file::Lz4::<F>::tempfile()?;
         let mut lazy_writer = file.lazy_writer()?;
         for item in input {
             lazy_writer.write_item(item)?;

--- a/martian-filetypes/src/lz4_file.rs
+++ b/martian-filetypes/src/lz4_file.rs
@@ -22,16 +22,14 @@
 //! fn main() -> Result<(), Error> {
 //!     let chem = Chemistry { name: "SCVDJ".into(), paired_end: true };
 //!     // --------------------- Json ----------------------------------
-//!     let lz4_json_file = Lz4::from_filetype(JsonFile::from("example")); // example.json.lz4
-//!     // lz4_json_file has the type Lz4<JsonFile>
+//!     let lz4_json_file: Lz4<JsonFile<_>> = "example".into(); // example.json.lz4
 //!     lz4_json_file.write(&chem)?; // Writes lz4 compressed json file
 //!     let decoded: Chemistry = lz4_json_file.read()?;
 //!     assert_eq!(chem, decoded);
 //!     # std::fs::remove_file(lz4_json_file)?; // Remove the file (hidden from the doc)
 //!
 //!     // --------------------- Bincode ----------------------------------
-//!     let lz4_bin_file: Lz4<BincodeFile<_>> = Lz4::from("example"); // example.bincode.lz4
-//!     // Need to explcitly annotate the type id you are using from() or MartianFileType::new()
+//!     let lz4_bin_file: Lz4<BincodeFile<_>> = "example".into(); // example.bincode.lz4
 //!     lz4_bin_file.write(&chem)?; // Writes lz4 compressed bincode file
 //!     let decoded: Chemistry = lz4_bin_file.read()?;
 //!     assert_eq!(chem, decoded);

--- a/martian-filetypes/src/lz4_file.rs
+++ b/martian-filetypes/src/lz4_file.rs
@@ -106,21 +106,6 @@ martian_filetype_decorator! {
     pub struct Lz4, "lz4"
 }
 
-impl<F> Lz4<F>
-where
-    F: MartianFileType,
-{
-    /// Create an Lz4 wrapped filetype from a basic filetype
-    /// ```rust
-    /// use martian_filetypes::{lz4_file::Lz4, bin_file::BincodeFile};
-    /// let lz4_bin_file = Lz4::from_filetype(BincodeFile::<()>::from("example"));
-    /// assert_eq!(lz4_bin_file.as_ref(), std::path::Path::new("example.bincode.lz4"));
-    /// ```
-    pub fn from_filetype(source: F) -> Self {
-        Self::from(source.as_ref())
-    }
-}
-
 impl<F, T> FileTypeRead<T> for Lz4<F>
 where
     F: MartianFileType + FileTypeIO<T>,
@@ -275,6 +260,7 @@ mod tests {
     use super::*;
     use crate::json_file::JsonFile;
     use crate::LazyFileTypeIO;
+    use martian::MartianTempFile;
     use std::path::{Path, PathBuf};
 
     martian_derive::martian_filetype! {CompoundFile, "foo.bar"}
@@ -377,23 +363,13 @@ mod tests {
     }
 
     #[test]
-    fn test_lz4_from_filetype() {
-        assert_eq!(
-            Lz4::<JsonFile<()>>::new("/some/path/", "file"),
-            Lz4::from_filetype(JsonFile::new("/some/path/", "file"))
-        );
-    }
-
-    #[test]
     fn test_lz4_extension() {
         assert_eq!(Lz4::<JsonFile<()>>::extension(), "json.lz4");
     }
 
     #[test]
     fn test_json_lz4_lazy_write() -> Result<(), Error> {
-        let dir = tempfile::tempdir()?;
-        let json_file = JsonFile::new(dir.path(), "file");
-        let file = Lz4::from_filetype(json_file);
+        let file = Lz4::<JsonFile<_>>::tempfile()?;
         let mut writer = file.lazy_writer()?;
         for i in 0..10usize {
             writer.write_item(&i)?;
@@ -408,19 +384,19 @@ mod tests {
     }
 
     #[test]
-    fn test_json_lz4_lazy_write_no_finish() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = Lz4::<JsonFile<Vec<usize>>>::new(dir.path(), "file");
-        let mut writer = file.lazy_writer().unwrap();
+    fn test_json_lz4_lazy_write_no_finish() -> Result<(), Error> {
+        let file = Lz4::<JsonFile<Vec<usize>>>::tempfile()?;
+        let mut writer = file.lazy_writer()?;
         for i in 0..10 {
-            writer.write_item(&i).unwrap();
+            writer.write_item(&i)?;
         }
         drop(writer);
-        let reader = file.lazy_reader().unwrap();
+        let reader = file.lazy_reader()?;
         for (i, val) in reader.enumerate() {
-            let val: usize = val.unwrap();
+            let val: usize = val?;
             assert_eq!(val, i);
         }
+        Ok(())
     }
 
     #[test]

--- a/martian-filetypes/src/tabular_file.rs
+++ b/martian-filetypes/src/tabular_file.rs
@@ -392,6 +392,7 @@ where
 mod tests {
     use super::*;
     use crate::LazyFileTypeIO;
+    use martian::MartianTempFile;
 
     #[derive(Serialize, Deserialize, PartialEq, Default)]
     struct Cell {
@@ -414,11 +415,10 @@ mod tests {
 
     #[test]
     fn test_csv_write() -> Result<(), Error> {
-        let dir = tempfile::tempdir()?;
-        let cells_csv = CsvFile::new(dir.path(), "test");
+        let cells_csv = CsvFile::tempfile()?;
         cells_csv.write(&cells())?;
         assert_eq!(
-            std::fs::read_to_string(&cells_csv)?,
+            std::fs::read_to_string(cells_csv.as_ref())?,
             "barcode,genome\nACGT,hg19\nTCAT,mm10\n"
         );
         Ok(())
@@ -426,11 +426,10 @@ mod tests {
 
     #[test]
     fn test_tsv_write() -> Result<(), Error> {
-        let dir = tempfile::tempdir()?;
-        let cells_tsv = TsvFile::new(dir.path(), "test");
+        let cells_tsv = TsvFile::tempfile()?;
         cells_tsv.write(&cells())?;
         assert_eq!(
-            std::fs::read_to_string(&cells_tsv)?,
+            std::fs::read_to_string(cells_tsv.as_ref())?,
             "barcode\tgenome\nACGT\thg19\nTCAT\tmm10\n"
         );
         assert_eq!(
@@ -442,11 +441,10 @@ mod tests {
 
     #[test]
     fn test_tsv_write_no_header() -> Result<(), Error> {
-        let dir = tempfile::tempdir()?;
-        let cells_tsv = TsvFileNoHeader::new(dir.path(), "test");
+        let cells_tsv = TsvFileNoHeader::tempfile()?;
         cells_tsv.write(&cells())?;
         assert_eq!(
-            std::fs::read_to_string(&cells_tsv)?,
+            std::fs::read_to_string(cells_tsv.as_ref())?,
             "ACGT\thg19\nTCAT\tmm10\n"
         );
         assert!(cells_tsv.read_headers()?.is_none());
@@ -481,22 +479,23 @@ mod tests {
 
     #[test]
     fn test_lazy_header_only() -> Result<(), Error> {
-        let dir = tempfile::tempdir()?;
-        let cells_tsv: TsvFile<Cell> = TsvFile::new(dir.path(), "test");
+        let cells_tsv = TsvFile::<Cell>::tempfile()?;
         let mut writer = cells_tsv.lazy_writer()?;
         writer.write_header()?;
         writer.finish()?;
-        assert_eq!(std::fs::read_to_string(&cells_tsv)?, "barcode\tgenome\n");
+        assert_eq!(
+            std::fs::read_to_string(cells_tsv.as_ref())?,
+            "barcode\tgenome\n"
+        );
         Ok(())
     }
 
     #[test]
     fn test_lazy_no_header() -> Result<(), Error> {
-        let dir = tempfile::tempdir()?;
-        let cells_tsv: TsvFile<Cell> = TsvFile::new(dir.path(), "test");
+        let cells_tsv = TsvFile::<Cell>::tempfile()?;
         let writer = cells_tsv.lazy_writer()?;
         writer.finish()?;
-        assert_eq!(std::fs::read_to_string(&cells_tsv)?, "");
+        assert_eq!(std::fs::read_to_string(cells_tsv.as_ref())?, "");
         Ok(())
     }
 }

--- a/martian-filetypes/src/zstd_file.rs
+++ b/martian-filetypes/src/zstd_file.rs
@@ -22,16 +22,14 @@
 //! fn main() -> Result<(), Error> {
 //!     let chem = Chemistry { name: "SCVDJ".into(), paired_end: true };
 //!     // --------------------- Json ----------------------------------
-//!     let zstd_json_file = Zstd::from_filetype(JsonFile::from("example")); // example.json.zst
-//!     // zstd_json_file has the type Zstd<JsonFile>
+//!     let zstd_json_file: Zstd<JsonFile<_>> = "example".into(); // example.json.zst
 //!     zstd_json_file.write(&chem)?; // Writes zstd compressed json file
 //!     let decoded: Chemistry = zstd_json_file.read()?;
 //!     assert_eq!(chem, decoded);
 //!     # std::fs::remove_file(zstd_json_file)?; // Remove the file (hidden from the doc)
 //!
 //!     // --------------------- Bincode ----------------------------------
-//!     let zstd_bin_file: Zstd<BincodeFile<_>> = Zstd::from("example"); // example.bincode.zst
-//!     // Need to explcitly annotate the type id you are using from() or MartianFileType::new()
+//!     let zstd_bin_file: Zstd<BincodeFile<_>> = "example".into(); // example.bincode.zst
 //!     zstd_bin_file.write(&chem)?; // Writes zstd compressed bincode file
 //!     let decoded: Chemistry = zstd_bin_file.read()?;
 //!     assert_eq!(chem, decoded);

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -28,6 +28,9 @@ pub use metadata::*;
 mod macros;
 
 mod stage;
+mod temporary_file;
+pub use temporary_file::*;
+
 pub mod utils;
 pub use stage::*;
 

--- a/martian/src/temporary_file.rs
+++ b/martian/src/temporary_file.rs
@@ -1,0 +1,48 @@
+//! Helper trait for creating temporary typed martian files.
+
+use crate::MartianFileType;
+use std::ops::Deref;
+use tempfile::NamedTempFile;
+
+/// Own a temporary file and deref to the underlying martian file type.
+pub struct TypedTempFile<F: MartianFileType> {
+    _tempfile: NamedTempFile,
+    f: F,
+}
+
+impl<F> Deref for TypedTempFile<F>
+where
+    F: MartianFileType,
+{
+    type Target = F;
+    fn deref(&self) -> &Self::Target {
+        &self.f
+    }
+}
+
+impl<F> AsRef<F> for TypedTempFile<F>
+where
+    F: MartianFileType,
+{
+    fn as_ref(&self) -> &F {
+        &self.f
+    }
+}
+
+/// Create temporary files for martian file types.
+/// Ensures the file extension complies with martian's expectations.
+pub trait MartianTempFile: MartianFileType {
+    fn tempfile() -> std::io::Result<TypedTempFile<Self>>;
+}
+
+impl<F: MartianFileType> MartianTempFile for F {
+    fn tempfile() -> std::io::Result<TypedTempFile<Self>> {
+        let f = tempfile::Builder::new()
+            .suffix(&format!(".{}", Self::extension()))
+            .tempfile()?;
+        Ok(TypedTempFile {
+            f: Self::from_path(f.path()),
+            _tempfile: f,
+        })
+    }
+}


### PR DESCRIPTION
Adds the `MartianTempFile` trait, providing a `tempfile()` method that creates a temporary file that complies with the naming expectations of the file type.  The `TypedTempFile<F>` returned by the method owns a temporary file and thus manages the tempfile lifetime, and implements `Deref` and `AsRef` for the underlying file type.

This is both convenient and avoids the confusing footgun of creating a martian file from a temp file and then it is apparently not there, because martian is adding the expectation of a particular extension.

I chose to implement this as a separate trait because it is kind of orthogonal to `MartianFileType` and is generally used in test contexts.  However, since `tempfile` is already a dependency, I didn't need to do anything like making the trait only be implemented when `#[cfg(test)]`.  If we think it would aid discoverability, I could move this method directly into `MartianFileType`.