### PR TITLE
Add a convenience method for writing to a martian file builder-style

### DIFF
--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -230,11 +230,11 @@ pub trait FileTypeWrite<T>: MartianFileType {
 /// Something that can create a Martian file and eagerly write into it.
 pub trait FileTypeCreate<T, F: FileTypeWrite<T>> {
     /// Create a Martian file of type F and immediately write T into it.
-    fn create(&self, file_name: &str, contents: &T) -> Result<F, Error>;
+    fn create_file(&self, file_name: &str, contents: &T) -> Result<F, Error>;
 }
 
 impl<T, F: FileTypeWrite<T>> FileTypeCreate<T, F> for MartianRover {
-    fn create(&self, file_name: &str, contents: &T) -> Result<F, Error> {
+    fn create_file(&self, file_name: &str, contents: &T) -> Result<F, Error> {
         let file: F = self.make_path(file_name);
         file.write(contents)?;
         Ok(file)

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -119,7 +119,7 @@
 //! ## Examples
 //! Look at the individual filetype modules for examples.
 
-use martian::{Error, MartianFileType};
+use martian::{Error, MartianFileType, MartianRover};
 use std::fs::File;
 use std::iter::FromIterator;
 use std::path::PathBuf;
@@ -219,6 +219,13 @@ pub trait FileTypeWrite<T>: MartianFileType {
         }
         <Self as FileTypeWrite<T>>::write_into(self.buf_writer()?, item)
             .map_err(|e| _fmt_err(e, self.as_ref().into()))
+    }
+
+    /// Create an instance of this file type and immediately write contents into it.
+    fn create(rover: &MartianRover, file_name: &str, contents: &T) -> Result<Self, Error> {
+        let file: Self = rover.make_path(file_name);
+        file.write(contents)?;
+        Ok(file)
     }
 
     #[doc(hidden)]

--- a/martian-filetypes/src/lib.rs
+++ b/martian-filetypes/src/lib.rs
@@ -119,7 +119,7 @@
 //! ## Examples
 //! Look at the individual filetype modules for examples.
 
-use martian::{Error, MartianFileType, MartianRover};
+use martian::{Error, MartianFileType};
 use std::fs::File;
 use std::iter::FromIterator;
 use std::path::PathBuf;
@@ -221,24 +221,18 @@ pub trait FileTypeWrite<T>: MartianFileType {
             .map_err(|e| _fmt_err(e, self.as_ref().into()))
     }
 
+    /// Write type `T` into the `MartianFileType`, transferring ownership.
+    /// This allows the creation of a martian file as well as writing a datatype
+    /// into that file as a single method call chain.
+    fn with_content(self, item: &T) -> Result<Self, Error> {
+        self.write(item)?;
+        Ok(self)
+    }
+
     #[doc(hidden)]
     // In general, do not call this function directly. Use `write()` instead.
     // The comments provided in `read_from()` apply here as well.
     fn write_into<W: io::Write>(writer: W, item: &T) -> Result<(), Error>;
-}
-
-/// Something that can create a Martian file and eagerly write into it.
-pub trait FileTypeCreate<T, F: FileTypeWrite<T>> {
-    /// Create a Martian file of type F and immediately write T into it.
-    fn create_file(&self, file_name: &str, contents: &T) -> Result<F, Error>;
-}
-
-impl<T, F: FileTypeWrite<T>> FileTypeCreate<T, F> for MartianRover {
-    fn create_file(&self, file_name: &str, contents: &T) -> Result<F, Error> {
-        let file: F = self.make_path(file_name);
-        file.write(contents)?;
-        Ok(file)
-    }
 }
 
 /// A trait that represents a `MartianFileType` that can be read into


### PR DESCRIPTION
Adds a method to `FileTypeWrite`, `with_content`, which transfers ownership of the file type through the method call, allowing for method chaining like `rover.make_path(...).with_content(...)`, so file creation and writing can happen in a single line without an intermediate let binding.