### PR TITLE
feat: thread shared metadata file into rover to enable use of alarm

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,7 +9,7 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: dtolnay/rust-toolchain@1.66.1
+    - uses: dtolnay/rust-toolchain@1.70.0
       with:
         components: clippy
     - uses: actions/checkout@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@1.66.0
+      - uses: dtolnay/rust-toolchain@1.70.0
 
       - name: Cargo doc
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: dtolnay/rust-toolchain@1.66.0
+    - uses: dtolnay/rust-toolchain@1.70.0
       with:
         components: rustfmt
     - uses: actions/checkout@v3

--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -152,7 +152,7 @@ pub fn make_mro(
     // struct. We can build the `stage_name()` function from the struct name.
     // TODO: This might also be a good time to check that the implementation is
     // actually for a unit struct. But is it possible?
-    let stage_struct = item_impl.self_ty.clone();
+    let stage_struct = item_impl.self_ty;
     let stage_struct_name = match *stage_struct {
         Type::Path(ref ty_path) => {
             let segments = &ty_path.path.segments;

--- a/martian-filetypes/src/bin_file.rs
+++ b/martian-filetypes/src/bin_file.rs
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_lazy_read() -> Result<(), Error> {
-        let values: Vec<u16> = (0..100).into_iter().collect();
+        let values: Vec<u16> = (0..100).collect();
         let bin_file = BincodeFile::tempfile()?;
         bin_file.write(&values)?;
 

--- a/martian-filetypes/tests/ui/invalid_type_read.stderr
+++ b/martian-filetypes/tests/ui/invalid_type_read.stderr
@@ -2,7 +2,7 @@ error[E0308]: `?` operator has incompatible types
   --> tests/ui/invalid_type_read.rs:27:37
    |
 27 |         let new_feature: Creature = feat_file.read()?; // Compiler error
-   |                                     ^^^^^^^^^^^^^^^^^ expected struct `Creature`, found struct `Feature`
+   |                                     ^^^^^^^^^^^^^^^^^ expected `Creature`, found `Feature`
    |
    = note: `?` operator cannot convert from `Feature` to `Creature`
 
@@ -10,6 +10,6 @@ error[E0308]: `?` operator has incompatible types
   --> tests/ui/invalid_type_read.rs:34:37
    |
 34 |         let new_feature: Creature = feat_file.read()?; // Compiler error
-   |                                     ^^^^^^^^^^^^^^^^^ expected struct `Creature`, found struct `Feature`
+   |                                     ^^^^^^^^^^^^^^^^^ expected `Creature`, found `Feature`
    |
    = note: `?` operator cannot convert from `Feature` to `Creature`

--- a/martian-filetypes/tests/ui/invalid_type_write.stderr
+++ b/martian-filetypes/tests/ui/invalid_type_write.stderr
@@ -2,13 +2,13 @@ error[E0308]: mismatched types
   --> tests/ui/invalid_type_write.rs:26:25
    |
 26 |         feat_file.write(&creature)?; // This is a compiler error
-   |                   ----- ^^^^^^^^^ expected struct `Feature`, found struct `Creature`
+   |                   ----- ^^^^^^^^^ expected `&Feature`, found `&Creature`
    |                   |
-   |                   arguments to this function are incorrect
+   |                   arguments to this method are incorrect
    |
    = note: expected reference `&Feature`
               found reference `&Creature`
-note: associated function defined here
+note: method defined here
   --> src/lib.rs
    |
    |     fn write(&self, item: &T) -> Result<(), Error> {
@@ -18,13 +18,13 @@ error[E0308]: mismatched types
   --> tests/ui/invalid_type_write.rs:31:25
    |
 31 |         feat_file.write(&creature)?; // This is a compiler error
-   |                   ----- ^^^^^^^^^ expected struct `Feature`, found struct `Creature`
+   |                   ----- ^^^^^^^^^ expected `&Feature`, found `&Creature`
    |                   |
-   |                   arguments to this function are incorrect
+   |                   arguments to this method are incorrect
    |
    = note: expected reference `&Feature`
               found reference `&Creature`
-note: associated function defined here
+note: method defined here
   --> src/lib.rs
    |
    |     fn write(&self, item: &T) -> Result<(), Error> {

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -261,13 +261,14 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
 
     let md = Rc::new(RefCell::new(md));
 
-    let result = match md.borrow().stage_type.as_str() {
-        "split" => stage.split(md.clone()),
-        "main" => stage.main(md.clone()),
-        "join" => stage.join(md.clone()),
-        unknown => {
-            panic!("Unrecognized stage type: {unknown}");
-        }
+    let result = if md.borrow().stage_type == "split" {
+        stage.split(md.clone())
+    } else if md.borrow().stage_type == "main" {
+        stage.main(md.clone())
+    } else if md.borrow().stage_type == "join" {
+        stage.join(md.clone())
+    } else {
+        panic!("Unrecognized stage type");
     };
 
     match result {

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -9,14 +9,14 @@ pub use anyhow::Error;
 use anyhow::{format_err, Context};
 use backtrace::Backtrace;
 use log::{error, info};
-use std::cell::RefCell;
+
 use std::collections::HashMap;
 use std::fmt::Write as FmtWrite;
 use std::fs::File;
 use std::io::Write as IoWrite;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::path::Path;
-use std::rc::Rc;
+
 use std::{io, panic};
 use time::format_description::modifier::{Day, Hour, Minute, Month, Second, Year};
 use time::format_description::FormatItem::Literal;
@@ -360,7 +360,6 @@ pub fn make_mro_string(header_comment: &str, mro_registry: &[StageMro]) -> Strin
         assert!(
             header_comment
                 .lines()
-                .into_iter()
                 .all(|line| line.trim_end().is_empty() || line.starts_with('#')),
             "All non-empty header lines must start with '#', but got\n{}",
             header_comment

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -261,14 +261,13 @@ fn martian_entry_point<S: std::hash::BuildHasher>(
 
     let md = Rc::new(RefCell::new(md));
 
-    let result = if md.borrow().stage_type == "split" {
-        stage.split(md.clone())
-    } else if md.borrow().stage_type == "main" {
-        stage.main(md.clone())
-    } else if md.borrow().stage_type == "join" {
-        stage.join(md.clone())
-    } else {
-        panic!("Unrecognized stage type");
+    let result = match md.borrow().stage_type.as_str() {
+        "split" => stage.split(md.clone()),
+        "main" => stage.main(md.clone()),
+        "join" => stage.join(md.clone()),
+        unknown => {
+            panic!("Unrecognized stage type: {unknown}");
+        }
     };
 
     match result {

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -469,15 +469,12 @@ impl MartianStruct for MartianVoid {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum Volatile {
     #[default]
     Strict,
     False,
 }
-
-
 
 impl From<&Volatile> for &'static str {
     fn from(v: &Volatile) -> Self {

--- a/martian/src/mro.rs
+++ b/martian/src/mro.rs
@@ -470,16 +470,14 @@ impl MartianStruct for MartianVoid {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default)]
 pub enum Volatile {
+    #[default]
     Strict,
     False,
 }
 
-impl Default for Volatile {
-    fn default() -> Self {
-        Volatile::Strict
-    }
-}
+
 
 impl From<&Volatile> for &'static str {
     fn from(v: &Volatile) -> Self {

--- a/martian/src/stage.rs
+++ b/martian/src/stage.rs
@@ -7,12 +7,9 @@ use log::warn;
 use rayon::prelude::*;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::{Path, PathBuf};
-
-
 
 /// A struct which needs to be used as one of the associated types in `MartianMain` or
 /// `MartianStage` if it is empty. For example, a stage with no chunk inputs, would

--- a/martian/src/stage.rs
+++ b/martian/src/stage.rs
@@ -1,18 +1,18 @@
 use crate::metadata::{Metadata, Version};
 use crate::mro::{MartianStruct, MroMaker};
 use crate::utils::obj_encode;
-use crate::{make_timestamp_now, Error, SharedFile};
+use crate::{Error, SharedFile};
 use log::warn;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
+
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
-use std::sync::Arc;
+
+
 
 /// A struct which needs to be used as one of the associated types in `MartianMain` or
 /// `MartianStage` if it is empty. For example, a stage with no chunk inputs, would
@@ -806,9 +806,8 @@ mod test {
     #[test]
     fn test_stage_def_extend() {
         let _stagedef = StageDef::from_iter([0, 1, 2]);
-        let _stagedef: StageDef<usize> = (0..3).into_iter().collect();
+        let _stagedef: StageDef<usize> = (0..3).collect();
         let _stagedef = (0..3)
-            .into_iter()
             .zip(std::iter::repeat(Resource::default()))
             .collect::<StageDef<usize>>()
             .join_resource(Resource::default());

--- a/martian/src/stage.rs
+++ b/martian/src/stage.rs
@@ -493,7 +493,7 @@ impl MartianRover {
     /// Add a message to the martian alarm system.
     /// If this rover was not initialized with metadata, such as in test mode,
     /// log at warning level instead.
-    pub fn alarm(&mut self, message: &str) -> Result<(), Error> {
+    pub fn alarm(&self, message: &str) -> Result<(), Error> {
         if let Some(md) = &self.metadata {
             md.borrow_mut().alarm(message)
         } else {

--- a/martian/src/stage.rs
+++ b/martian/src/stage.rs
@@ -1,7 +1,7 @@
 use crate::metadata::{Metadata, Version};
 use crate::mro::{MartianStruct, MroMaker};
 use crate::utils::obj_encode;
-use crate::Error;
+use crate::{make_timestamp_now, Error, SharedFile};
 use log::warn;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -12,6 +12,7 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// A struct which needs to be used as one of the associated types in `MartianMain` or
 /// `MartianStage` if it is empty. For example, a stage with no chunk inputs, would
@@ -399,24 +400,19 @@ pub struct MartianRover {
     threads: usize,
     vmem_gb: usize,
     version: Version,
-    metadata: Option<Rc<RefCell<Metadata>>>,
+    alarm_file: Option<SharedFile>,
 }
 
-impl From<Rc<RefCell<Metadata>>> for MartianRover {
-    fn from(md: Rc<RefCell<Metadata>>) -> MartianRover {
-        let mut r = {
-            let md_ref = md.borrow();
-            MartianRover {
-                files_path: PathBuf::from(&md_ref.files_path),
-                mem_gb: md_ref.jobinfo.mem_gb,
-                threads: md_ref.jobinfo.threads,
-                vmem_gb: md_ref.jobinfo.vmem_gb,
-                version: md_ref.jobinfo.version.clone(),
-                metadata: None,
-            }
-        };
-        r.metadata = Some(md);
-        r
+impl From<&Metadata> for MartianRover {
+    fn from(md: &Metadata) -> MartianRover {
+        MartianRover {
+            files_path: PathBuf::from(&md.files_path),
+            mem_gb: md.jobinfo.mem_gb,
+            threads: md.jobinfo.threads,
+            vmem_gb: md.jobinfo.vmem_gb,
+            version: md.jobinfo.version.clone(),
+            alarm_file: Some(md.alarm_file().clone()),
+        }
     }
 }
 
@@ -442,7 +438,7 @@ impl MartianRover {
             threads: resource.threads.unwrap() as usize,
             vmem_gb: resource.vmem_gb.unwrap() as usize,
             version: Version::default(),
-            metadata: None,
+            alarm_file: None,
         }
     }
     ///
@@ -494,8 +490,8 @@ impl MartianRover {
     /// If this rover was not initialized with metadata, such as in test mode,
     /// log at warning level instead.
     pub fn alarm(&self, message: &str) -> Result<(), Error> {
-        if let Some(md) = &self.metadata {
-            md.borrow_mut().alarm(message)
+        if let Some(f) = &self.alarm_file {
+            f.appendln(message, true)
         } else {
             warn!("{message}");
             Ok(())
@@ -674,9 +670,9 @@ pub trait MartianStage: MroMaker {
 /// A raw martian stage that works with untype metadata. It is recommended
 /// not to implement this directly. Use `MartianMain` or `MartianStage` traits instead
 pub trait RawMartianStage {
-    fn split(&self, metadata: Rc<RefCell<Metadata>>) -> Result<(), Error>;
-    fn main(&self, metadata: Rc<RefCell<Metadata>>) -> Result<(), Error>;
-    fn join(&self, metadata: Rc<RefCell<Metadata>>) -> Result<(), Error>;
+    fn split(&self, metadata: &mut Metadata) -> Result<(), Error>;
+    fn main(&self, metadata: &mut Metadata) -> Result<(), Error>;
+    fn join(&self, metadata: &mut Metadata) -> Result<(), Error>;
 }
 
 impl<T> MartianStage for T
@@ -746,33 +742,32 @@ impl<T> RawMartianStage for T
 where
     T: MartianStage,
 {
-    fn split(&self, md: Rc<RefCell<Metadata>>) -> Result<(), Error> {
-        let args: <T as MartianStage>::StageInputs = md.borrow().decode(ARGS_FN)?;
-        let rover: MartianRover = MartianRover::from(md.clone());
+    fn split(&self, md: &mut Metadata) -> Result<(), Error> {
+        let args: <T as MartianStage>::StageInputs = md.decode(ARGS_FN)?;
+        let rover: MartianRover = MartianRover::from(&*md);
         let stage_defs = MartianStage::split(self, args, rover)?;
         let stage_def_obj = obj_encode(&stage_defs)?;
-        md.borrow_mut().complete_with("stage_defs", &stage_def_obj)
+        md.complete_with("stage_defs", &stage_def_obj)
     }
 
-    fn main(&self, md: Rc<RefCell<Metadata>>) -> Result<(), Error> {
-        let args: <T as MartianStage>::StageInputs = md.borrow().decode(ARGS_FN)?;
-        let chunk_args: <T as MartianStage>::ChunkInputs = md.borrow().decode(ARGS_FN)?;
-        let rover = MartianRover::from(md.clone());
+    fn main(&self, md: &mut Metadata) -> Result<(), Error> {
+        let args: <T as MartianStage>::StageInputs = md.decode(ARGS_FN)?;
+        let chunk_args: <T as MartianStage>::ChunkInputs = md.decode(ARGS_FN)?;
+        let rover = MartianRover::from(&*md);
         let outs = MartianStage::main(self, args, chunk_args, rover)?;
         let outs_obj = obj_encode(&outs)?;
-        md.borrow_mut().complete_with(OUTS_FN, &outs_obj)
+        md.complete_with(OUTS_FN, &outs_obj)
     }
 
-    fn join(&self, md: Rc<RefCell<Metadata>>) -> Result<(), Error> {
-        let args: <T as MartianStage>::StageInputs = md.borrow().decode(ARGS_FN)?;
-        let rover = MartianRover::from(md.clone());
+    fn join(&self, md: &mut Metadata) -> Result<(), Error> {
+        let args: <T as MartianStage>::StageInputs = md.decode(ARGS_FN)?;
+        let rover = MartianRover::from(&*md);
         // let outs = md.read_json_obj("outs")?;
-        let chunk_defs: Vec<<T as MartianStage>::ChunkInputs> = md.borrow().decode("chunk_defs")?;
-        let chunk_outs: Vec<<T as MartianStage>::ChunkOutputs> =
-            md.borrow().decode("chunk_outs")?;
+        let chunk_defs: Vec<<T as MartianStage>::ChunkInputs> = md.decode("chunk_defs")?;
+        let chunk_outs: Vec<<T as MartianStage>::ChunkOutputs> = md.decode("chunk_outs")?;
         let outs = MartianStage::join(self, args, chunk_defs, chunk_outs, rover)?;
         let outs_obj = obj_encode(&outs)?;
-        md.borrow_mut().complete_with(OUTS_FN, &outs_obj)
+        md.complete_with(OUTS_FN, &outs_obj)
     }
 }
 


### PR DESCRIPTION
Create an abstraction for thread-safe shared ownership of stage metadata files, `SharedFile`.  Use this to share access to the `alarm` file between `Metadata` and `MartianRover`.