### PR TITLE
build: Bump edition to 2021 in martian-lab

### DIFF
--- a/martian-lab/Cargo.toml
+++ b/martian-lab/Cargo.toml
@@ -2,7 +2,7 @@
 name = "martian-lab"
 version = "0.1.0"
 authors = ["Sreenath Krishnan <sreenathk.89@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 include = ["src/lib.rs"]
 


### PR DESCRIPTION
Bump `edition` to `2021` in `martian-lab`.
