### PR TITLE
fix: use the first line of struct field doc as MRO doc comment

### DIFF
--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -518,11 +518,15 @@ pub fn martian_struct(item: proc_macro::TokenStream) -> proc_macro::TokenStream 
                 }
 
                 mro_type = Some(val.value())
-            } else if attr.path().is_ident("doc") {
+            } else if attr.path().is_ident("doc") && doc_comment.is_none() {
                 if let Meta::NameValue(meta) = &attr.meta {
                     if let Expr::Lit(elit) = &meta.value {
                         if let Lit::Str(lstr) = &elit.lit {
-                            doc_comment = Some(lstr.value());
+                            let val = lstr.value();
+                            let trimmed = val.trim();
+                            if !trimmed.is_empty() {
+                                doc_comment = Some(trimmed.to_string());
+                            }
                         }
                     }
                 }
@@ -568,7 +572,7 @@ pub fn martian_struct(item: proc_macro::TokenStream) -> proc_macro::TokenStream 
 
         let doc_comment_code = match doc_comment {
             Some(t) => {
-                quote![Some(#t.trim_start().to_string())]
+                quote![Some(#t.to_string())]
             }
             None => quote![None],
         };

--- a/martian-derive/tests/mro/test_struct.mro
+++ b/martian-derive/tests/mro/test_struct.mro
@@ -13,7 +13,7 @@ struct SampleDef(
 
 struct Config(
     SampleDef[] sample_def     "The sample definition",
-    path        reference_path "even more info about reference path"               "the_reference_path",
+    path        reference_path "The reference path"                                "the_reference_path",
     int         force_cells    "The number of cells to force the pipeline to call",
     json        primers        "The primer definitions as a JSON file"             "renamed_primers_json.json",
 )


### PR DESCRIPTION
Improves the struct field documentation -> MRO doc comment feature to use the first non-empty line of the struct field doc comment rather than the last.