### PR TITLE
Silence clippy::needless_update for fully specified MroUsing.

### DIFF
--- a/martian-derive/src/lib.rs
+++ b/martian-derive/src/lib.rs
@@ -105,6 +105,7 @@ pub fn make_mro(
     };
     let using_attributes_fn = quote![
         fn using_attributes() -> ::martian::MroUsing {
+            #[allow(clippy::needless_update)]
             ::martian::MroUsing {
                 #mem_gb_quote
                 #threads_quote


### PR DESCRIPTION
Any stage that specifies all four MroUsing parameters will trigger `clippy::needless_update` since the final `..Default::default()` will set no fields. Silence it locally.