### PR TITLE
feat(mro): Improve martian_make_mro

### DIFF
--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -360,8 +360,7 @@ pub fn make_mro_string(header_comment: &str, mro_registry: &[StageMro]) -> Strin
             header_comment
                 .lines()
                 .all(|line| line.trim_end().is_empty() || line.starts_with('#')),
-            "All non-empty header lines must start with '#', but got\n{}",
-            header_comment
+            "All non-empty header lines must start with '#', but got\n{header_comment}"
         );
         format!(
             "{}

--- a/martian/src/lib.rs
+++ b/martian/src/lib.rs
@@ -19,6 +19,7 @@ use time::format_description::modifier::{Day, Hour, Minute, Month, Second, Year}
 use time::format_description::FormatItem::Literal;
 use time::format_description::{Component, FormatItem};
 use time::OffsetDateTime;
+use utils::current_executable;
 
 mod metadata;
 pub use metadata::*;
@@ -76,7 +77,7 @@ fn write_errors(msg: &str, is_assert: bool) -> Result<()> {
 // We could use the proc macro, but then we'd need
 // to compile the proc macro crate, which would slow down build times
 // significantly for very little benefit in readability.
-pub(crate) const DATE_FORMAT: &[FormatItem] = &[
+pub(crate) const DATE_FORMAT: &[FormatItem<'_>] = &[
     FormatItem::Component(Component::Year(Year::default())),
     Literal(b"-"),
     FormatItem::Component(Component::Month(Month::default())),
@@ -283,16 +284,9 @@ fn report_error(md: &mut Metadata, e: &Error, is_assert: bool) {
     let _ = write_errors(&format!("{e:#}"), is_assert);
 }
 
+/// Return the environment variable CARGO_PKG_NAME or the current executable name.
 fn get_generator_name() -> String {
-    std::env::var("CARGO_BIN_NAME")
-        .or_else(|_| std::env::var("CARGO_CRATE_NAME"))
-        .or_else(|_| std::env::var("CARGO_PKG_NAME"))
-        .unwrap_or_else(|_| {
-            option_env!("CARGO_BIN_NAME")
-                .or(option_env!("CARGO_CRATE_NAME"))
-                .unwrap_or("martian-rust")
-                .into()
-        })
+    std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| current_executable())
 }
 
 /// Write MRO to filename or stdout.

--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -179,7 +179,7 @@ impl Metadata {
 
     /// Update the Martian journal -- so that Martian knows what we've updated
     fn update_journal(&self, name: &str) -> Result<()> {
-        let journal_name: Cow<str> = if self.stage_type != "main" {
+        let journal_name: Cow<'_, str> = if self.stage_type != "main" {
             format!("{}_{name}", self.stage_type).into()
         } else {
             name.into()

--- a/martian/src/utils.rs
+++ b/martian/src/utils.rs
@@ -52,12 +52,14 @@ pub fn to_camel_case(stage_name: &str) -> String {
 /// Parse the `env::args()` and return the name of the
 /// current executable as a String
 pub fn current_executable() -> String {
-    let args: Vec<_> = std::env::args().collect();
-    std::path::Path::new(&args[0])
+    Path::new(&std::env::args().next().unwrap())
+        .canonicalize()
+        .unwrap()
         .file_name()
         .unwrap()
-        .to_string_lossy()
-        .into_owned()
+        .to_str()
+        .unwrap()
+        .to_string()
 }
 
 /// Given a filename and an extension, return the filename with the correct extension.


### PR DESCRIPTION
- Improve error message of `martian_make_mro`
- Use `current_executable` as fallback in `get_generator_name`
- Deref symlinks in `current_executable`

Slack: <https://10xgenomics.slack.com/archives/CJT1RB554/p1717443208330939>
