### PR TITLE
fix: serde default for vmemGB

### DIFF
--- a/martian/src/metadata.rs
+++ b/martian/src/metadata.rs
@@ -44,6 +44,7 @@ pub struct JobInfo {
     #[serde(rename = "memGB")]
     pub mem_gb: f64,
     #[serde(rename = "vmemGB")]
+    #[serde(default)]
     pub vmem_gb: f64,
     pub version: Version,
     #[serde(default)]


### PR DESCRIPTION
The underlying martian go process will skip serializing vmemGB if it has the zero value (indicates vmem isn't being limited or monitored). Use a serde default annotation for vmemGB to handle this case.